### PR TITLE
Enable SSH to the guest machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,49 @@ You can also pass optional parameters
   --restore  : Restore the snapshot.
   --snapshot : Create a disk snapshot.
   --virgil   : Use virgil, if available.
+  --ssh      : Enable SSH to the machine (disabled by default).
+  --ssh-port : Local port to forward to the machine (default 2222).
+```
+
+### SSH Access
+
+SSH access to the QEMU virtual machine can be enabled by using the `--ssh` flag. This will portforward `TCP2222` on the host machine to `TCP22` on the QEMU guest machine. This does not install or start an SSH server within the guest itself, so you will stil need to enable this on a per-guest basis. For Ubuntu guests, you can enable this by installing `openssh-server`.
+
+If the default port overlaps with another service on your host, you can override this with `--ssh-port $PORT`. This will still forward to port `TCP22` on the guest machine.
+
+Example of usage: -
+
+```
+$ ./quickemu.sh --vm mate.conf --ssh --ssh-port 1111
+Starting mate.conf
+ - BIOS:     Legacy
+ - Disk:     /home/$USER/Applications/quickemu/ubuntu-mate/focal-desktop-amd64.qcow2
+ - Size:     20G
+ - ISO:      /home/$USER/Applications/quickemu/ubuntu-mate/focal-desktop-amd64.iso
+ - CPU:      2 Core(s)
+ - RAM:      2G
+ - UI:       sdl
+ - GL:       on
+ - smbd:     /home/stuh84 will be exported to the guest via smb://10.0.2.4/qemu
+
+$ ssh quickemu@localhost -p 1111
+quickemu@localhost's password: 
+Welcome to Ubuntu Focal Fossa (development branch) (GNU/Linux 5.4.0-18-generic x86_64)
+
+ * Documentation:  https://help.ubuntu.com
+ * Management:     https://landscape.canonical.com
+ * Support:        https://ubuntu.com/advantage
+
+
+
+The programs included with the Ubuntu system are free software;
+the exact distribution terms for each program are described in the
+individual files in /usr/share/doc/*/copyright.
+
+Ubuntu comes with ABSOLUTELY NO WARRANTY, to the extent permitted by
+applicable law.
+
+quickemu@ubuntu-mate:~$
 ```
 
 ## TODO

--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ You can also pass optional parameters
   --snapshot : Create a disk snapshot.
   --virgil   : Use virgil, if available.
   --ssh      : Enable SSH to the machine (disabled by default).
-  --ssh-port : Local port to forward to the machine (default 2222).
 ```
 
 ### SSH Access
@@ -84,12 +83,12 @@ SSH access to the QEMU virtual machine can be enabled by using the `--ssh` flag.
 
 This does not install or start an SSH server within the guest itself, so you may need to enable this on a per-guest basis. For Ubuntu guests, you can enable this by installing `openssh-server`.
 
-If the default port overlaps with another service on your host, you can override this with `--ssh-port $PORT`. This will still forward to port `TCP22` on the guest machine.
+If the default port overlaps with another service on your host, you can override this with `--ssh $PORT`. This will still forward to port `TCP22` on the guest machine.
 
 Example of usage: -
 
 ```
-$ ./quickemu.sh --vm mate.conf --ssh --ssh-port 1111
+$ ./quickemu.sh --vm mate.conf --ssh 1111
 Starting mate.conf
  - BIOS:     Legacy
  - Disk:     /home/$USER/Applications/quickemu/ubuntu-mate/focal-desktop-amd64.qcow2

--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ You can also pass optional parameters
 
 ### SSH Access
 
-SSH access to the QEMU virtual machine can be enabled by using the `--ssh` flag. This will portforward `TCP2222` on the host machine to `TCP22` on the QEMU guest machine. This does not install or start an SSH server within the guest itself, so you will stil need to enable this on a per-guest basis. For Ubuntu guests, you can enable this by installing `openssh-server`.
+SSH access to the QEMU virtual machine can be enabled by using the `--ssh` flag. This will portforward `TCP2222` on the host machine to `TCP22` on the QEMU guest machine. 
+
+This does not install or start an SSH server within the guest itself, so you may need to enable this on a per-guest basis. For Ubuntu guests, you can enable this by installing `openssh-server`.
 
 If the default port overlaps with another service on your host, you can override this with `--ssh-port $PORT`. This will still forward to port `TCP22` on the guest machine.
 

--- a/quickemu.sh
+++ b/quickemu.sh
@@ -178,12 +178,12 @@ function usage() {
   echo "  ${LAUNCHER} --vm ubuntu.conf"
   echo
   echo "You can also pass optional parameters"
-  echo "  --delete   : Delete the disk image."
-  echo "  --efi      : Enable EFI BIOS (experimental)."
-  echo "  --restore  : Restore the snapshot."
-  echo "  --snapshot : Create a disk snapshot."
-  echo "  --virgil   : Use virgil, if available."
-  echo "  --ssh      : Enable SSH to the machine (disabled by default)."
+  echo "  --delete       : Delete the disk image."
+  echo "  --efi          : Enable EFI BIOS (experimental)."
+  echo "  --restore      : Restore the snapshot."
+  echo "  --snapshot     : Create a disk snapshot."
+  echo "  --virgil       : Use virgil, if available."
+  echo "  --ssh [<PORT>] : Enable SSH to the machine, default port 2222."
   exit 1
 }
 

--- a/quickemu.sh
+++ b/quickemu.sh
@@ -141,8 +141,10 @@ function vm_boot() {
   #
   if [ ${SSH} -eq 1 ]; then
       SSH_FWD=",hostfwd=tcp::${SSH_PORT}-:22"
+      echo " - ssh:     SSH is enabled on ${SSH_PORT} - ssh USER@localhost -p ${SSH_PORT}."
   else
       SSH_FWD=""
+      echo " - ssh:     SSH is not enabled."
   fi
 
 

--- a/quickemu.sh
+++ b/quickemu.sh
@@ -184,7 +184,6 @@ function usage() {
   echo "  --snapshot : Create a disk snapshot."
   echo "  --virgil   : Use virgil, if available."
   echo "  --ssh      : Enable SSH to the machine (disabled by default)."
-  echo "  --ssh-port : Local port to forward to the machine (default 2222)."
   exit 1
 }
 
@@ -196,7 +195,6 @@ ENGINE="system-x86_64"
 RESTORE=0
 SNAPSHOT=0
 SSH=0
-SSH_PORT=2222
 VM=""
 
 while [ $# -gt 0 ]; do
@@ -218,10 +216,12 @@ while [ $# -gt 0 ]; do
       shift;;
     -ssh|--ssh)
       SSH=1
-      shift;;
-    -ssh-port|--ssh-port)
-      SSH_PORT=$2
-      shift
+      if [[ $2 =~ ^[0-9]+$ ]]; then
+        SSH_PORT=$2
+        shift
+      else
+        SSH_PORT=2222
+      fi
       shift;;
     -vm|--vm)
       VM="$2"


### PR DESCRIPTION
This PR enables SSH to be port forwarded to the guest machine, with a default host port of TCP2222. This will then forward to the guest on port 22.

This also adds the ability to override the port that is forwarded (if it clashes with another port used locally).

Let me know if anything needs to change on it, either code style, documentation, or any problems found.