### PR TITLE
Fix parsing RAM amount on non-English systems.

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+export LC_ALL=C
 
 function disk_delete() {
   if [ -e "${disk_img}" ]; then


### PR DESCRIPTION
Export LC_ALL=C to force free and friends back to English.