### PR TITLE
Added Desktop Shortcut feature - usage:

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ Starting /media/martin/Quickemu/ubuntu-focal-desktop.conf
 
   * Complete the installation as normal.
 
+  * A Desktop shortcut can be created (in ~/.local/share/applications):
+```
+./quickemu --shortcut --vm ubuntu-focal-desktop.conf
+```
+
 ### Windows 10
 
 You can use `quickemu` to run a Windows 10 virtual machine.
@@ -160,6 +165,7 @@ Usage
 
 You can also pass optional parameters
   --delete                : Delete the disk image.
+  --shortcut              : Create a desktop shortcut
   --snapshot apply <tag>  : Apply/restore a snapshot.
   --snapshot create <tag> : Create a snapshot.
   --snapshot delete <tag> : Delete a snapshot.
@@ -169,7 +175,7 @@ You can also pass optional parameters
 
 ## TODO
 
-  - [ ] Create desktop launcher for a VM
+  - [x] Create desktop launcher for a VM
   - [ ] Improve disk management
   - [x] Add USB pass-through support
   - [x] Fix Virgil 3D on EFI boot

--- a/quickemu
+++ b/quickemu
@@ -8,6 +8,12 @@ function disk_delete() {
   else
     echo "NOTE! ${disk_img} not found. Doing nothing."
   fi
+  local VMNAME=$(basename "${VM}" .conf)
+  local SHORTCUT_DIR="/home/${USER}/.local/share/applications/"
+  if [ -e ~/.local/share/applications/${VMNAME}.desktop ]; then
+    rm -v "${SHORTCUT_DIR}/${VMNAME}.desktop"
+    echo "Deleted ${VM} desktop shortcut" 
+  fi
 }
 
 function snapshot_apply() {
@@ -377,6 +383,22 @@ function vm_boot() {
    fi
 }
 
+function shortcut_create {
+  local VMNAME=$(basename "${VM}" .conf)
+  local LAUNCHER_DIR="$(dirname "$(realpath "$0")")"
+  local filename="/home/${USER}/.local/share/applications/${VMNAME}.desktop"
+  cat << EOF > ${filename}
+[Desktop Entry]
+Version=1.0
+Type=Application
+Terminal=true
+Exec=${LAUNCHER_DIR}/${LAUNCHER} --vm ${VM}
+Name=${VMNAME}
+Icon=/snap/qemu-virgil/74/meta/gui/icon.png
+EOF
+  echo "created app.desktop file"
+}
+
 function usage() {
   echo
   echo "Usage"
@@ -384,6 +406,7 @@ function usage() {
   echo
   echo "You can also pass optional parameters"
   echo "  --delete                : Delete the disk image."
+  echo "  --shortcut              : Create a desktop shortcut"
   echo "  --snapshot apply <tag>  : Apply/restore a snapshot."
   echo "  --snapshot create <tag> : Create a snapshot."
   echo "  --snapshot delete <tag> : Delete a snapshot."
@@ -408,6 +431,7 @@ SNAPSHOT_TAG=""
 STATUS_QUO=""
 USB_PASSTHOUGH=""
 VM=""
+SHORTCUT=0
 
 readonly LAUNCHER=$(basename "${0}")
 readonly DISK_MIN_SIZE=$((197632 * 8))
@@ -440,6 +464,10 @@ while [ $# -gt 0 ]; do
     -vm|--vm)
       VM="${2}"
       shift
+      shift;;
+    -shortcut|--shortcut)
+      SHORTCUT=1
+      echo "shortcut is" ${SHORTCUT}
       shift;;
     -h|--h|-help|--help)
       usage;;
@@ -493,6 +521,12 @@ if [ -n "${SNAPSHOT_ACTION}" ]; then
       echo "ERROR! \"${SNAPSHOT_ACTION}\" is not a supported snapshot action."
       usage;;
   esac
+fi
+
+if [ ${SHORTCUT} -eq 1 ]; then
+  echo "VM=" ${VM}
+  shortcut_create
+  exit
 fi
 
 vm_boot


### PR DESCRIPTION
### Desktop Shortcut feature
Hi Martin,
`quickemu --shortcut --vm <VMNAME>.conf`
.desktop added to user profile `~/.local/share/applications folder`
The icon for virgil is used.
When the VM is --deleted, the .desktop file is removed.
Updated the README.md also.

 TODO Proposal - Add parameters options to be added to <vm>.conf file:

- SHORTCUT=1 # Add shortcut when vm is created
- ICON=<path to custom icon> # User can add distro logo icon from web

This is my first Git Pull request, i hope I've submitted it correctly.

Regards, 
Mark Crouch