### PR TITLE
Enable arbitrary port forwarding via config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ guest_os="linux"
 iso="/media/$USER/Quickemu/ubuntu/focal-desktop-amd64.iso"
 disk_img="/media/$USER/Quickemu/ubuntu/focal-desktop-amd64.qcow2"
 disk=128G
+port_forwards=("8123:8123" "8888:80")
 usb_devices=("046d:082d" "046d:085e")
 ```
 
@@ -83,6 +84,9 @@ Starting /media/martin/Quickemu/ubuntu-focal-desktop.conf
  - Display:  SDL
  - smbd:     /home/martin will be exported to the guest via smb://10.0.2.4/qemu
  - ssh:      22221/tcp is connected. Login via 'ssh user@localhost -p 22221'
+ - PORTS:    Port forwards requested:
+              - 8123 => 8123
+              - 8888 => 80
  - USB:      Device pass-through requested:
               - Logitech, Inc. HD Pro Webcam C920
               - Logitech, Inc. Logitech BRIO
@@ -113,6 +117,7 @@ iso="/media/$USER/Quickemu/windows10/Win10_1909_English_x64.iso"
 driver_iso="/media/$USER/Quickemu/windows10/virtio-win-0.1.173.iso"
 disk_img="/media/$USER/Quickemu/windows10/windows10.qcow2"
 disk=128G
+port_forwards=("8123:8123" "8888:80")
 usb_devices=("046d:082d" "046d:085e")
 ```
 
@@ -142,7 +147,10 @@ Starting /media/martin/Quickemu/windows10.conf
  - Display:  SDL
  - smbd:     /home/martin will be exported to the guest via smb://10.0.2.4/qemu
  - ssh:      22221/tcp is connected. Login via 'ssh user@localhost -p 22221'
- - USB:      Device pass-through requested:
+ - PORTS:    Port forwards requested:
+              - 8123 => 8123
+              - 8888 => 80
+- USB:      Device pass-through requested:
               - Logitech, Inc. HD Pro Webcam C920
               - Logitech, Inc. Logitech BRIO
              Requested USB device(s) are accessible.
@@ -198,6 +206,7 @@ guest_os="macos"
 img="/media/$USER/Quickemu/macos/BaseSystem.img"
 disk_img="/media/$USER/Quickemu/macos/macos.qcow2"
 disk=128G
+port_forwards=("8123:8123" "8888:80")
 usb_devices=("046d:082d" "046d:085e")
 ```
 
@@ -225,6 +234,9 @@ Starting macos.conf
  - Display:  SDL
  - smbd:     /home/martin will be exported to the guest via smb://10.0.2.4/qemu
  - ssh:      22223/tcp is connected. Login via 'ssh user@localhost -p 22223'
+ - PORTS:    Port forwards requested:
+              - 8123 => 8123
+              - 8888 => 80
 ```
 
   * Boot from the BaseSystem

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Starting /media/martin/Quickemu/windows10.conf
  - PORTS:    Port forwards requested:
               - 8123 => 8123
               - 8888 => 80
-- USB:      Device pass-through requested:
+ - USB:      Device pass-through requested:
               - Logitech, Inc. HD Pro Webcam C920
               - Logitech, Inc. Logitech BRIO
              Requested USB device(s) are accessible.

--- a/quickemu
+++ b/quickemu
@@ -150,6 +150,22 @@ enable_usb_passthrough() {
   fi
 }
 
+function enable_port_forwards() {
+  local HOSTFWDS=""
+
+  # Have any port forwards been requested?
+  if (( ${#port_forwards[@]} )); then
+    SEPARATOR=""
+    for FORWARD in "${port_forwards[@]}"; do
+      HOST_PORT=$(echo ${FORWARD} | cut -d':' -f1)
+      GUEST_PORT=$(echo ${FORWARD} | cut -d':' -f2)
+      HOSTFWDS="${HOSTFWDS}${SEPARATOR}hostfwd=tcp::${HOST_PORT}-:${GUEST_PORT}"
+      SEPARATOR=","
+    done
+  fi
+  echo ${HOSTFWDS}
+}
+
 function vm_boot() {
   local VMNAME=$(basename "${VM}" .conf)
   local VMDIR=$(dirname "${disk_img}")
@@ -368,6 +384,12 @@ function vm_boot() {
     echo " - ssh:      ${PORT}/tcp is connected. Login via 'ssh user@localhost -p ${PORT}'"
   else
     echo " - ssh:      All ports for exposing ssh have been exhausted."
+  fi
+
+  local HOSTFWDS=$(enable_port_forwards)
+  if [ ! -z "${HOSTFWDS}" ]; then
+    echo " - ports:    forwarding requested ports"
+    NET="${NET},${HOSTFWDS}"
   fi
 
   # Find a free port for spice

--- a/quickemu
+++ b/quickemu
@@ -388,7 +388,7 @@ function vm_boot() {
   fi
 
   enable_usb_passthrough
-exit
+
   # Boot the iso image
   if [ "${boot}" == "efi" ] || [ "${boot}" == "uefi" ]; then
     if [ "${guest_os}" == "macos" ]; then

--- a/quickemu
+++ b/quickemu
@@ -150,22 +150,6 @@ enable_usb_passthrough() {
   fi
 }
 
-function enable_port_forwards() {
-  local HOSTFWDS=""
-
-  # Have any port forwards been requested?
-  if (( ${#port_forwards[@]} )); then
-    SEPARATOR=""
-    for FORWARD in "${port_forwards[@]}"; do
-      HOST_PORT=$(echo ${FORWARD} | cut -d':' -f1)
-      GUEST_PORT=$(echo ${FORWARD} | cut -d':' -f2)
-      HOSTFWDS="${HOSTFWDS}${SEPARATOR}hostfwd=tcp::${HOST_PORT}-:${GUEST_PORT}"
-      SEPARATOR=","
-    done
-  fi
-  echo ${HOSTFWDS}
-}
-
 function vm_boot() {
   local VMNAME=$(basename "${VM}" .conf)
   local VMDIR=$(dirname "${disk_img}")
@@ -386,10 +370,15 @@ function vm_boot() {
     echo " - ssh:      All ports for exposing ssh have been exhausted."
   fi
 
-  local HOSTFWDS=$(enable_port_forwards)
-  if [ ! -z "${HOSTFWDS}" ]; then
-    echo " - ports:    forwarding requested ports"
-    NET="${NET},${HOSTFWDS}"
+  # Have any port forwards been requested?
+  if (( ${#port_forwards[@]} )); then
+    echo " - PORTS:    Port forwards requested:"
+    for FORWARD in "${port_forwards[@]}"; do
+      HOST_PORT=$(echo ${FORWARD} | cut -d':' -f1)
+      GUEST_PORT=$(echo ${FORWARD} | cut -d':' -f2)
+      echo "              - ${HOST_PORT} => ${GUEST_PORT}"
+      NET="${NET},hostfwd=tcp::${HOST_PORT}-:${GUEST_PORT}"
+    done
   fi
 
   # Find a free port for spice
@@ -399,7 +388,7 @@ function vm_boot() {
   fi
 
   enable_usb_passthrough
-
+exit
   # Boot the iso image
   if [ "${boot}" == "efi" ] || [ "${boot}" == "uefi" ]; then
     if [ "${guest_os}" == "macos" ]; then


### PR DESCRIPTION
In order to run Home Assistant in a VM, I need certain ports to be forwarded from my machine to my VM, so I can access the web interface or the embeded MQTT server.
I've looked at how th USB passthrough was made and tried to replicate that for forwards.