### PR TITLE
Github Actions: Run shellcheck against PRs

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,12 @@
+name: Run shellcheck on Pull Requests
+
+on:
+- pull_request
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: |
+        find $GITHUB_WORKSPACE -type f -and \( -name "*.sh" -or -name "quickemu" \) | xargs shellcheck


### PR DESCRIPTION
See Issue #38 
This PR enables checking every Pull Request with `shellckeck`
Currently, `shellcheck` throws quite a lot of warnings and infos. When I've got the time, I'll create another PR where I'll attempt to fix those.
Would it be sensible to ignore the `info` level of `shellcheck` for the automatic testing?