### PR TITLE
Feature : --screen command line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,35 @@ You can also pass optional parameters
   --status-quo            : Do not commit any changes to disk/snapshot.
   --fullscreen            : Starts VM in full screen mode (Ctl+Alt+f to exit)"
   --no-smb                : Do not expose the home directory via SMB.
+  --screen <screen>       : Use specified screen to determine the window size.
 ```
+
+<ins>Note about screen and window size</ins>
+
+`qemu` will always default to the primary monitor to display the VM's window.
+
+Without the `--screen` option, `quickemu` will look for the size of the smallest monitor, and use a size that fits on said monitor.
+
+The `--screen` option forces `quickemu` to use the size of the given monitor to compute the size of the window. **It wont't use that monitor to display the VM's window if it's not the primary monitor**. This is usefull if the primary monitor if not the smallest one, and if the VM's window doesn't need to be moved around.
+
+The `--screen` option is also usefull with the `--fullscreen` option, again because `qemu` will always use the primary monitor. In order for the fullscreen mode to work properly, the resolution of the VM's window must match the resolution of the screen.
+
+To know which screen to use, type :
+```
+xrandr --listmonitors | grep -v Monitors
+```
+The command will output something like this :
+```
+ 0: +*HDMI-0 2560/597x1440/336+1920+0  HDMI-0
+ 1: +DVI-D-0 1920/527x1080/296+0+0  DVI-D-0
+```
+The first number is what needs to be passed to the `--screen` option.
+
+For example : 
+```
+quickemu --vm vm.conf --screen 0
+```
+will use my big screen to compute the size of the window, and make it 2048x1152. Without the `--screen` option, it would have used the smallest monitor and make the window 1664x936.
 
 ## TODO
 

--- a/quickemu
+++ b/quickemu
@@ -319,10 +319,19 @@ function vm_boot() {
   local Y_RES=648
   if [ "${XDG_SESSION_TYPE}" == "x11" ]; then
     local LOWEST_WIDTH=""
-    LOWEST_WIDTH=$(xrandr --listmonitors | grep -v Monitors | cut -d' ' -f4 | cut -d'/' -f1 | sort | head -n1)
+    if [ -z "${SCREEN}" ]; then
+      LOWEST_WIDTH=$(xrandr --listmonitors | grep -v Monitors | cut -d' ' -f4 | cut -d'/' -f1 | sort | head -n1)
+    else
+      LOWEST_WIDTH=$(xrandr --listmonitors | grep -v Monitors | grep "^ ${SCREEN}:" | cut -d' ' -f4 | cut -d'/' -f1 | head -n1)
+    fi
     if [ "${FULLSCREEN}" ]; then
-      X_RES=$(xrandr --listmonitors | grep -v Monitors | cut -d' ' -f4 | cut -d'/' -f1 | sort | head -n1)
-      Y_RES=$(xrandr --listmonitors | grep -v Monitors | cut -d' ' -f4 | cut -d'/' -f2 | cut -d'x' -f2 | sort | head -n1)
+      if [ -z "${SCREEN}" ]; then
+        X_RES=$(xrandr --listmonitors | grep -v Monitors | cut -d' ' -f4 | cut -d'/' -f1 | sort | head -n1)
+        Y_RES=$(xrandr --listmonitors | grep -v Monitors | cut -d' ' -f4 | cut -d'/' -f2 | cut -d'x' -f2 | sort | head -n1)
+      else
+        X_RES=$(xrandr --listmonitors | grep -v Monitors | grep "^ ${SCREEN}:" | cut -d' ' -f4 | cut -d'/' -f1 | head -n1)
+        Y_RES=$(xrandr --listmonitors | grep -v Monitors | grep "^ ${SCREEN}:" | cut -d' ' -f4 | cut -d'/' -f2 | cut -d'x' -f2 | head -n1)
+      fi
     elif [ "${LOWEST_WIDTH}" -ge 3840 ]; then
       X_RES=3200
       Y_RES=1800
@@ -555,6 +564,7 @@ STATUS_QUO=""
 USB_PASSTHROUGH=""
 VM=""
 SHORTCUT=0
+SCREEN=""
 
 readonly LAUNCHER=$(basename "${0}")
 readonly DISK_MIN_SIZE=$((197632 * 8))
@@ -605,6 +615,10 @@ else
             shift;;
           -vm|--vm)
             VM="${2}"
+            shift
+            shift;;
+          -screen|--screen)
+            SCREEN="${2}"
             shift
             shift;;
           -shortcut|--shortcut)


### PR DESCRIPTION
This option allows to select which screen is used to compute the window's size. 
Usefull when the main monitor is not the smallest one, and the VM doesn't need to be moved around. 
Also mandatory to make the fullscreen mode work properly.