### PR TITLE
Fixed : problem with the generated shell script.

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -679,8 +679,15 @@ function vm_boot() {
           ${USB_PASSTHROUGH})
   fi
 
+  # The OSK parameter contains parenthesis, they need to be escaped in the shell scripts
+  # The vendor name, Wimpys World, contains a space. It needs to be double-quoted.
+  SHELL_ARGS="${args[*]}"
+  SHELL_ARGS="${SHELL_ARGS//(/\\(}"
+  SHELL_ARGS="${SHELL_ARGS//)/\\)}"
+  SHELL_ARGS="${SHELL_ARGS//Wimpys World/\"Wimpys World\"}"
+  
   echo "#!/usr/bin/env bash" > "${VMDIR}/${VMNAME}.sh"
-  echo "${QEMU}" "${args[@]}" >> "${VMDIR}/${VMNAME}.sh"
+  echo "${QEMU}" "${SHELL_ARGS}" >> "${VMDIR}/${VMNAME}.sh"
 
   ${QEMU} "${args[@]}" > "${VMDIR}/${VMNAME}.log" &
   echo -e " - Process:  On guest: killall ${VMNAME}\t(if a forced kill is required)"


### PR DESCRIPTION
The OSK parameter contains parenthesis, they need to be escaped in the shell scripts.
The vendor name, Wimpys World, contains a space. It needs to be double-quoted.