### PR TITLE
Add FreeBSD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,18 @@ quickemu --vm windows-10.conf
     * Download and install [UsbDk](https://www.spice-space.org/download/windows/usbdk/)
       * Enables USB SPICE pass-through between the host and guest.
 
+### FreeBSD Guest
+`quickemu` supports FreeBSD production releases. FreeBSD support is maintained by `<kai@potabi.com>`.
+
+FreeBSD version command reference (just in case):
+* 12.2: `12_2`
+* 13.0: `13_0`
+
+```bash
+quickget freebsd 13_0
+quickemu --vm freebsd-13_0.conf
+```
+
 ### Regional versions
 
 By default `quickget` will download the *"English International"* release, but

--- a/quickget
+++ b/quickget
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 function os_support() {
-    echo kubuntu \
+    echo freebsd \
+    kubuntu \
     lubuntu \
     macos \
     ubuntu \
@@ -11,6 +12,12 @@ function os_support() {
     ubuntu-studio \
     windows \
     xubuntu
+}
+
+function releases_freebsd(){
+    echo 13_0 \
+    12_2 # replace with 12.3 upon release
+    # 14_0 # Waiting for 14.0 release
 }
 
 function releases_macos() {

--- a/quickget
+++ b/quickget
@@ -135,7 +135,10 @@ function make_vm_config() {
     local GUEST=""
     IMAGE_FILE="${1}"
     ISO_FILE="${2}"
-    if [[ "${OS}" == *"ubuntu"* ]]; then
+    if [[ "${OS}" == "freebsd" ]]; then
+        GUEST="freebsd"
+        IMAGE_TYPE="iso"
+    elif [[ "${OS}" == *"ubuntu"* ]]; then
         GUEST="linux"
         IMAGE_TYPE="iso"
     elif [ "${OS}" == "macos" ]; then
@@ -168,6 +171,39 @@ function start_vm_info() {
     echo "To start your ${OS} ${RELEASE} virtual machine run:"
     echo "    quickemu --vm ${OS}-${RELEASE}.conf"
     echo
+}
+
+function get_freebsd() {
+    # For future releases, use dvd1 iso files.
+    local URL=""
+    local CHECKSUMS=""
+    local DL_BASE="https://download.freebsd.org/ftp/releases/amd64/amd64/ISO-IMAGES"
+    local VERSION=""
+    case ${RELEASE} in
+        13_0)
+            VERSION="13.0"
+        ;;
+        12_2)
+            VERSION="12.2"
+        ;;
+        # Waiting until FreeBSD 14 release
+        # 14_0)
+        #     VERSION="14.0"
+        # ;;
+        *)
+            echo "ERROR! FreeBSD ${RELEASE} is not a supported release."
+            releases_freebsd
+            exit 1
+        ;;
+    esac
+
+    URL="${DL_BASE}/${VERSION}/FreeBSD-${VERSION}-RELEASE-amd64-dvd1.iso"
+
+    ISO="FreeBSD-${VERSION}-RELEASE-amd64-dvd1.iso"
+    web_get ${URL} ${VM_PATH}
+    make_vm_dir
+    make_vm_config ${ISO}
+    start_vm_info
 }
 
 function get_macos() {
@@ -382,6 +418,8 @@ VM_PATH="${OS}-${RELEASE}"
 
 if [ "${OS}" == "macos" ]; then
     get_macos
+elif [[ "${OS}" == *"freebsd" ]]; then
+    get_freebsd
 elif [[ "${OS}" == *"ubuntu"* ]]; then
     get_ubuntu
 elif [ "${OS}" == "windows" ]; then


### PR DESCRIPTION
Currently this has had been tested, it functions as intended (Solus MATE 4.3 with QEMU 6.0.0). I would recommend further testing just in case. I have already prepared work for FreeBSD 14.0, and 12.2 will be replaced with 12.3 on release (12.2 will essentially be in EOL). 