### PR TITLE
Deal with systems without xdg-user-dir better

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ See this (old) video where I explain some of my motivations for creating Quickem
   * [spicy](https://gitlab.freedesktop.org/spice/spice-gtk)
   * [swtpm](https://github.com/stefanberger/swtpm)
   * [Wget](https://www.gnu.org/software/wget/)
-  * [xdg-user-dirs](https://www.freedesktop.org/wiki/Software/xdg-user-dirs/)
   * [xrandr](https://gitlab.freedesktop.org/xorg/app/xrandr)
   * [zsync](http://zsync.moria.org.uk/)
 

--- a/quickemu
+++ b/quickemu
@@ -825,15 +825,18 @@ readonly VERSION="2.2.2"
 
 # PUBLICSHARE is the only directory exposed to guest VMs for file
 # sharing via 9P and spice-webdavd. This path is not configurable.
-PUBLIC=$(xdg-user-dir PUBLICSHARE)
-if [ "${PUBLIC}" != ${HOME} ]; then
-  if [ ! -d "${PUBLIC}" ]; then
-    mkdir -p "${PUBLIC}"
+PUBLIC=""
+if command -v xdg-user-dir &>/dev/null; then
+  PUBLIC=$(xdg-user-dir PUBLICSHARE)
+  if [ "${PUBLIC%/}" != ${HOME} ]; then
+    if [ ! -d "${PUBLIC}" ]; then
+      mkdir -p "${PUBLIC}"
+    fi
+    PUBLIC_TAG=$(basename ${PUBLIC})-${USER,,}
+    PUBLIC_PERMS=$(ls -ld ${PUBLIC} | cut -d' ' -f1)
+  else
+    PUBLIC=""
   fi
-  PUBLIC_TAG=$(basename ${PUBLIC})-${USER,,}
-  PUBLIC_PERMS=$(ls -ld ${PUBLIC} | cut -d' ' -f1)
-else
-  PUBLIC=""
 fi
 
 # TODO: Make this run the native architecture binary


### PR DESCRIPTION
My system doesn't have xdg-user-dir, and shows the following errors on
startup:

	./quickemu: line 828: xdg-user-dir: command not found
	mkdir: cannot create directory '': No such file or directory
	basename: missing operand
	Try 'basename --help' for more information.

	Usage
	quickemu --vm ubuntu.conf

	You can also pass optional parameters
	--delete                : Delete the disk image.
	--display               : Select display backend. 'sdl' (default), 'gtk' or 'spice'
	--shortcut              : Create a desktop shortcut
	--snapshot apply <tag>  : Apply/restore a snapshot.
	--snapshot create <tag> : Create a snapshot.
	--snapshot delete <tag> : Delete a snapshot.
	--snapshot info         : Show disk/snapshot info.
	--status-quo            : Do not commit any changes to disk/snapshot.
	--fullscreen            : Starts VM in full screen mode (Ctl+Alt+f to exit)
	--screen <screen>       : Use specified screen to determine the window size.
	--version               : Print version

From a quick look it should still function correctly, but better to deal
with this case explicitly.

It's only used to get the PUBLIC, which is optional anyway. If I install
it then it just returns ~, at which point it's set to "" anyway.

I also removed it from the list of "requirements" for this reason.

This also deals with an edge case I happened to notice: "xdg-user-dir
PUBLICSHARE" returns "/home/martin/" on my system, whereas $HOME is
"/home/martin", so the equality check fails. This is arguable a problem
in xdg-user-dir, but better to fix it here. This only deals with a
single slash (multiple slashes is harder in bash), which should be
sufficient.