### PR TITLE
Create unattended directory for Windows

### DIFF
--- a/quickget
+++ b/quickget
@@ -82,6 +82,7 @@ function releases_windows() {
 }
 
 function unattended_windows() {
+    mkdir -p "$(dirname "${1}")"
     cat << 'EOF' > "${1}"
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend"


### PR DESCRIPTION
It will try to write "windows-10/unattended/autounattend.xml", but the
windows-10/unattended/ directory may not exist yet, so create it first
if it doesn't.

Fixes #64