### PR TITLE
Adding impish to the Ubuntu releases for quickget

### DIFF
--- a/quickget
+++ b/quickget
@@ -30,6 +30,7 @@ function releases_ubuntu() {
     echo bionic \
     focal \
     hirsute \
+    impish \
     devel
 }
 


### PR DESCRIPTION
This seems to be all there is to do so did this noddy one-liner as a tiny token of appreciation for the incredible work getting the release done.