### PR TITLE
Unable to start a linux VM.

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -489,7 +489,7 @@ function vm_boot() {
   fi
 
   # Determine a sane resolution for Linux guests.
-  if [ "${guest}" == "linux" ]; then
+  if [ "${guest_os}" == "linux" ]; then
     local X_RES=1152
     local Y_RES=648
     if [ "${XDG_SESSION_TYPE}" == "x11" ]; then


### PR DESCRIPTION
```
qemu-system-x86_64: -device virtio-vga,xres=,yres=: Parameter 'xres' expects uint64
```

This fixes a typo in the name of the variable used to determine a sane resolution for linux guests.