### PR TITLE
Added linuxmint support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ comprehensive support for macOS and Windows**.
   * Windows 8.1, 10 and 11 including TPM 2.0
   * Ubuntu, and all the official flavours, supported by `quickget`
   * Fedora, supported by `quickget`
+  * linuxmint Cinnamon, MATE, and xfce, supported by `quickget`
   * openSUSE Leap and Tumbleweed, supported by `quickget`
   * Full SPICE support including host/guest clipboard sharing
   * VirtIO-webdavd file sharing for Linux and Windows guests
@@ -294,6 +295,15 @@ quickemu --vm freebsd-13_0.conf
 ```bash
 quickget fedora 34
 quickemu --vm fedora-34.conf
+```
+
+## linuxmint Guest
+
+`quickemu` supports linuxmint releases.
+
+```bash
+quickget linuxmint mate-20_2
+quickemu --vm linuxmint-mate-20.2.conf
 ```
 
 ## openSUSE Guest

--- a/quickget
+++ b/quickget
@@ -4,6 +4,7 @@ function os_support() {
     echo freebsd \
     fedora \
     kubuntu \
+    linuxmint \
     lubuntu \
     macos \
     opensuse \
@@ -25,6 +26,12 @@ function releases_fedora(){
     echo 33 \
     34 \
     35_beta
+}
+
+function releases_linuxmint(){
+    echo cinnamon-20_2 \
+    mate-20_2 \
+    xfce-20-2
 }
 
 function releases_opensuse(){
@@ -350,6 +357,9 @@ function make_vm_config() {
     elif [[ "${OS}" == *"fedora"* ]]; then
         GUEST="linux"
         IMAGE_TYPE="iso"
+    elif [[ "${OS}" == *"linuxmint"* ]]; then
+        GUEST="linux"
+        IMAGE_TYPE="iso"
     elif [[ "${OS}" == *"opensuse"* ]]; then
         GUEST="linux"
         IMAGE_TYPE="iso"
@@ -458,6 +468,34 @@ function get_fedora() {
     fi
     cd ..
 
+    make_vm_config ${ISO}
+    start_vm_info
+}
+
+function get_linuxmint() {
+    local URL=""
+    local DL_BASE="https://mirrors.edge.kernel.org/linuxmint/stable"
+    local VERSION=""
+
+    case ${RELEASE} in
+        cinnamon-20_2|mate-20_2|xfce-20_2) VERSION=${RELEASE//_/.};;
+        *)
+            echo "ERROR! linuxmint ${RELEASE} is not a supported release."
+            releases_linuxmint
+            exit 1
+            ;;
+    esac
+
+    re='(.*)-(.*)'
+    [[ ${VERSION} =~ ${re} ]];
+    local FLAVOR=${BASH_REMATCH[1]}
+    VERSION=${BASH_REMATCH[2]}
+
+    ISO="linuxmint-${VERSION}-${FLAVOR}-64bit.iso"
+    URL="${DL_BASE}/${VERSION}/${ISO}"
+
+    make_vm_dir
+    web_get ${URL} ${VM_PATH}
     make_vm_config ${ISO}
     start_vm_info
 }
@@ -721,6 +759,8 @@ else
         releases_freebsd
     elif [ "${OS}" == "fedora" ]; then
         releases_fedora
+    elif [ "${OS}" == "linuxmint" ]; then
+        releases_linuxmint
     elif [ "${OS}" == "opensuse" ]; then
         releases_opensuse
     elif [ "${OS}" == "macos" ]; then
@@ -741,6 +781,8 @@ elif [[ "${OS}" == *"freebsd" ]]; then
     get_freebsd
 elif [[ "${OS}" == *"fedora"* ]]; then
     get_fedora
+elif [[ "${OS}" == *"linuxmint"* ]]; then
+    get_linuxmint
 elif [[ "${OS}" == *"opensuse"* ]]; then
     get_opensuse
 elif [[ "${OS}" == *"ubuntu"* ]]; then


### PR DESCRIPTION
quickget supports linuxmint cinnamon 20.2, MATE 20.2, and xfce 20.2

![image](https://user-images.githubusercontent.com/2527227/137600716-7eccc8d9-0db5-47b0-85e9-bbf4dfacc440.png)
