### PR TITLE
Add shallow clone flag to install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ sudo apt install quickemu
 ## Other Linux
 
 ```bash
-git clone https://github.com/wimpysworld/quickemu
+git clone --depth=1 https://github.com/wimpysworld/quickemu
 cd quickemu
 ```
 


### PR DESCRIPTION
Just adding `--depth=1` to the git clone command for folks copy-pasting the install directions. Figured it might save users a few bits of disk and network usage that they might not otherwise think about.