### PR TITLE
adding openSUSE MicroOS only

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ comprehensive support for macOS and Windows**.
   * Ubuntu, and all the official flavours, supported by `quickget`
   * Fedora, supported by `quickget`
   * linuxmint Cinnamon, MATE, and xfce, supported by `quickget`
-  * openSUSE Leap and Tumbleweed, supported by `quickget`
+  * openSUSE Leap, Tumbleweed and MicroOS, supported by `quickget`
   * Full SPICE support including host/guest clipboard sharing
   * VirtIO-webdavd file sharing for Linux and Windows guests
   * VirtIO-9p file sharing for Linux and macOS guests
@@ -308,7 +308,7 @@ quickemu --vm linuxmint-mate-20.2.conf
 
 ## openSUSE Guest
 
-`quickemu` supports openSUSE Leap and Tumbleweed.
+`quickemu` supports openSUSE Leap, Tumbleweed and MicroOS.
 
 For the installation to complete properly, on the "Installation Settings" screen,
 you need to disable the "Update NVRAM" option.
@@ -323,6 +323,11 @@ quickemu --vm opensuse-15_3.conf
 ```bash
 quickget opensuse tumbleweed
 quickemu --vm opensuse-tumbleweed
+```
+
+```bash
+quickget opensuse microos
+quickemu --vm opensuse-microos
 ```
 
 # SPICE

--- a/quickget
+++ b/quickget
@@ -39,7 +39,8 @@ function releases_opensuse(){
     15_1 \
     15_2 \
     15_3 \
-    tumbleweed
+    tumbleweed \
+    microos
 }
 
 function releases_macos() {
@@ -507,7 +508,7 @@ function get_opensuse() {
     local VERSION=""
 
     case ${RELEASE} in
-        15_0|15_1|15_2|15_3|tumbleweed) VERSION=${RELEASE//_/.};;
+        15_0|15_1|15_2|15_3|tumbleweed|microos) VERSION=${RELEASE//_/.};;
         *)
             echo "ERROR! openSUSE ${RELEASE} is not a supported release."
             releases_opensuse
@@ -517,6 +518,10 @@ function get_opensuse() {
 
     if [ "${VERSION}" == "tumbleweed" ]; then
         ISO="openSUSE-Tumbleweed-DVD-x86_64-Current.iso"
+        URL="${DL_BASE}/tumbleweed/iso/${ISO}"
+    elif
+        [ "${VERSION}" == "microos" ]; then
+        ISO="openSUSE-MicroOS-DVD-x86_64-Current.iso"
         URL="${DL_BASE}/tumbleweed/iso/${ISO}"
     else
         ISO="openSUSE-Leap-${VERSION}-DVD-x86_64.iso"


### PR DESCRIPTION
Following up on #121, adding openSUSE MicroOS support to `quickget`, which has [desktop roles](https://www.youtube.com/playlist?list=PLL0HHpqiEUpXjLD7UsrBWCVEluMy8Hb6S).