### PR TITLE
Disable all network interfaces during Windows install. Close #115

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,13 @@ and [Windows 11](https://www.microsoft.com/en-gb/software-download/windows11)
 along with the [VirtIO drivers for Windows](https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/)
 and creates a virtual machine configuration.
 
+**During the Windows install network interfaces are completely disabled!** This
+is to allow those users who want to create local accounts to do so. A side affect
+is that the first time **Windows boots with the QEMU network enabled it will blue
+screen, automatically restart and then start normally with fully functioning
+networking**.
+
+
 ```bash
 quickget windows 11
 quickemu --vm windows-11.conf

--- a/quickemu
+++ b/quickemu
@@ -687,7 +687,6 @@ function vm_boot() {
          -device usb-ehci,id=input
          -device usb-kbd,bus=input.0
          -device ${MOUSE},bus=input.0
-         -device ${NET_DEVICE},netdev=nic -netdev ${NET},id=nic
          -audiodev pa,id=audio0,out.mixing-engine=off,out.stream-name=${LAUNCHER}-${VMNAME},in.stream-name=${LAUNCHER}-${VMNAME}
          -device intel-hda -device hda-duplex,audiodev=audio0
          -rtc base=localtime,clock=host,driftfix=slew
@@ -699,6 +698,15 @@ function vm_boot() {
          -object rng-random,id=rng0,filename=/dev/urandom
          -monitor none
          -serial mon:stdio)
+
+  # Disables network interface during Windows install.
+  # See https://github.com/wimpysworld/quickemu/issues/115
+  if [ "${guest_os}" == "windows" ] && [ -n "${iso}" ]; then
+    args+=(-nic none)
+  else
+    # shellcheck disable=SC2054,SC2206
+    args+=(-device ${NET_DEVICE},netdev=nic -netdev ${NET},id=nic)
+  fi
 
   # Add the disks
   # - https://turlucode.com/qemu-disk-io-performance-comparison-native-or-threads-windows-10-version/


### PR DESCRIPTION
During the Windows install network interfaces are completely disabled! This is to allow those users who want to create local accounts to do so.

A side affect is that the first time Windows boots with the QEMU network enabled it will blue screen, automatically restart and then boot normally with fully functioning networking.