### PR TITLE
Enforce requirement of bash 4 or newer

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 export LC_ALL=C
 
+if ((BASH_VERSINFO[0] < 4))
+then
+  echo "Sorry, you need bash 4.0 or newer to run this script."
+  exit 1
+fi
+
 function ignore_msrs_always() {
   # Make sure the host has /etc/modprobe.d
   if [ -d /etc/modprobe.d ]; then

--- a/quickget
+++ b/quickget
@@ -23,6 +23,12 @@
 #     }
 #  6. Add new OS to the argument parser at the bottom of the script
 
+if ((BASH_VERSINFO[0] < 4))
+then
+  echo "Sorry, you need bash 4.0 or newer to run this script."
+  exit 1
+fi
+
 function pretty_name() {
   local SIMPLE_NAME=""
   local PRETTY_NAME=""


### PR DESCRIPTION
macOS Mojave (10.14) ships bash 3, which doesn't support {,,} to-lowercase parameter expansion. The output displayed is:
```
$ ./quickget windows
./quickget: line 866: ${1,,}: bad substitution
ERROR! You must specify a release for :
```
Maybe someday older versions of bash could be supported, but until then, enforce a minimum version requirement of 4.