### PR TITLE
fix OpenCore path from upstream repo

### DIFF
--- a/quickget
+++ b/quickget
@@ -716,7 +716,7 @@ function get_macos() {
     fi
 
     # Get firmware
-    web_get "https://github.com/kholia/OSX-KVM/raw/master/OpenCore-Catalina/OpenCore.qcow2" "${VM_PATH}"
+    web_get "https://github.com/kholia/OSX-KVM/raw/master/OpenCore/OpenCore.qcow2" "${VM_PATH}"
     web_get "https://github.com/kholia/OSX-KVM/raw/master/OVMF_CODE.fd" "${VM_PATH}"
     if [ ! -e "${VM_PATH}/OVMF_VARS-1024x768.fd" ]; then
         web_get "https://github.com/kholia/OSX-KVM/raw/master/OVMF_VARS-1024x768.fd" "${VM_PATH}"


### PR DESCRIPTION
Recent [commit](https://github.com/kholia/OSX-KVM/commit/1cc6430f96b452cb78b9a079c34bb9933144ce18) to OSX-KVM changes the path to OpenCore image. 