### PR TITLE
working link for elementary

### DIFF
--- a/quickget
+++ b/quickget
@@ -609,7 +609,7 @@ function get_elementary() {
 
     validate_release "releases_elementary"
     ISO="elementaryos-${RELEASE}-stable.20211005.iso"
-    URL="https://ams3.dl.elementary.io/download/MTYzNDU5MDA5NA==/${ISO}"
+    URL="https://ams3.dl.elementary.io/download/MTYzNTM1NDc4OQ==/${ISO}"
     web_get "${URL}" "${VM_PATH}"
     make_vm_config "${ISO}"
 }


### PR DESCRIPTION
The current download link returns an html file with a message about an expired link.  Ideally this needs to be fixed more elegantly by collaboration with the elementary team to get a stable/non-expiring link or find an alternate source ( or de-support elementary)