### PR TITLE
Added support for Zorin OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ comprehensive support for macOS and Windows**.
   * [Ubuntu](https://ubuntu.com/desktop) and all the **[official Ubuntu flavours](https://ubuntu.com/download/flavours)**
   * [Fedora](https://getfedora.org/) & openSUSE ([Leap](https://get.opensuse.org/leap/), [Tumbleweed](https://get.opensuse.org/tumbleweed/), [MicroOS](https://microos.opensuse.org/))
   * [Linux Mint](https://linuxmint.com/) (Cinnamon, MATE, and XFCE), [elementary OS](https://elementary.io/), [Pop!_OS](https://pop.system76.com/)
-  * [Arch Linux](https://www.archlinux.org/), [Kali](https://www.kali.org/) & [NixOS](https://nixos.org/)
+  * [Arch Linux](https://www.archlinux.org/), [Kali](https://www.kali.org/), [ZorinOS](https://zorin.com/os/) & [NixOS](https://nixos.org/)
   * [FreeBSD](https://www.freebsd.org/) & [OpenBSD](https://www.openbsd.org/)
   * Full SPICE support including host/guest clipboard sharing
   * VirtIO-webdavd file sharing for Linux and Windows guests
@@ -180,6 +180,7 @@ preferred flavour.
   * `nixos-gnome`
   * `nixos-plasma5`
   * `nixos-minimal`
+  * `zorin`
 
 Or you can download a Linux image and manually create a VM configuration.
 

--- a/quickget
+++ b/quickget
@@ -636,6 +636,12 @@ EOF
         if [ "${OS}" == "macos" ]; then
             echo "macos_release=\"${RELEASE}\"" >> "${OS}-${RELEASE}.conf"
         fi
+        if [ "${OS}" == "zorin"  ]; then 
+            case  ${RELEASE} in
+              15education64|15edulite64|15edulite32)
+                echo "disk_size=\"32G\"" >> "${OS}-${RELEASE}.conf";;
+            esac  
+        fi
 
         # Enable TPM for Windows 11
         if [ "${OS}" == "windows" ] && [ "${RELEASE}" -ge 11 ]; then

--- a/quickget
+++ b/quickget
@@ -52,6 +52,7 @@ function pretty_name() {
     ubuntu-kylin)       PRETTY_NAME="Ubuntu Kylin";;
     ubuntu-mate)        PRETTY_NAME="Ubuntu MATE";;
     ubuntu-studio)      PRETTY_NAME="Ubuntu Studio";;
+    zorin)              PRETTY_NAME="Zorin OS";;
     *)                  PRETTY_NAME="${SIMPLE_NAME^}";;
   esac
   echo "${PRETTY_NAME}"
@@ -149,7 +150,8 @@ function os_support() {
     ubuntu-mate \
     ubuntu-studio \
     windows \
-    xubuntu
+    xubuntu \
+    zorin
 }
 
 function releases_android() {
@@ -276,6 +278,12 @@ function releases_windows() {
     echo 8 \
     10 \
     11
+}
+
+function releases_zorin() {
+    echo 16core64 \
+    15lite64 \
+    15lite32
 }
 
 function unattended_windows() {
@@ -602,6 +610,9 @@ function make_vm_config() {
     elif [ "${OS}" == "windows" ]; then
         GUEST="windows"
         IMAGE_TYPE="iso"
+    elif [ "${OS}" == "zorin" ]; then
+        GUEST="zorin"
+        IMAGE_TYPE="iso"
     fi
 
     if [ ! -e "${OS}-${RELEASE}.conf" ]; then
@@ -803,6 +814,22 @@ function get_openbsd() {
     make_vm_config "${ISO}"
 }
 
+function get_zorin() {
+    #local HASH="" no hash provided
+    local ISO=""
+    local URL=""
+
+    validate_release "releases_zorin"
+    
+    URL=$(curl -s https://zrn.co/${RELEASE} |cut -d\" -f2) 
+    ISO=$(echo ${URL}| awk -F\/ ' {print $NF}') 
+    web_get "${URL}" "${VM_PATH}"
+    #check_hash "${ISO}" "${HASH}"
+    make_vm_config "${ISO}"
+
+}
+
+
 function get_opensuse() {
     local HASH=""
     local ISO=""
@@ -916,7 +943,11 @@ function get_popos() {
     check_hash "${ISO}" "${HASH}"
     make_vm_config "${ISO}"
 }
-
+# https://zrn.co/16core64
+#https://zrn.co/15lite64 -> https://zorin.com/os/download/15/lite/64/
+#https://zrn.co/15lite32 - https://zorin.com/os/download/15/lite/32/
+#(curl -s https://zrn.co/15lite32 |cut -d\" -f2) 
+#
 function get_ubuntu() {
     local DEVEL="daily-live"
     local ISO=""
@@ -1117,6 +1148,8 @@ if [ -n "${2}" ]; then
             LANG_NAME="English International"
         fi
         get_windows "${LANG_NAME}"
+    elif [ "${OS}" == "zorin" ]; then
+        get_zorin
     else
         echo "ERROR! ${OS} is unknown:"
         os_support
@@ -1150,6 +1183,8 @@ else
         releases_ubuntu
     elif [ "${OS}" == "windows" ]; then
         releases_windows
+    elif [ "${OS}" == "zorin" ]; then
+        releases_zorin        
     else
         echo "${OS} is unknown"
         os_support

--- a/quickget
+++ b/quickget
@@ -283,7 +283,10 @@ function releases_windows() {
 function releases_zorin() {
     echo 16core64 \
     15lite64 \
-    15lite32
+    15lite32 \
+    15education64 \
+    15edulite64 \
+    15edulite32
 }
 
 function unattended_windows() {

--- a/quickget
+++ b/quickget
@@ -614,7 +614,7 @@ function make_vm_config() {
         GUEST="windows"
         IMAGE_TYPE="iso"
     elif [ "${OS}" == "zorin" ]; then
-        GUEST="zorin"
+        GUEST="linux"
         IMAGE_TYPE="iso"
     fi
 

--- a/quickget
+++ b/quickget
@@ -818,18 +818,15 @@ function get_openbsd() {
 }
 
 function get_zorin() {
-    #local HASH="" no hash provided
     local ISO=""
     local URL=""
 
     validate_release "releases_zorin"
-    
+    # their redirector returns an href so we need to get that and parse out the iso   
     URL=$(curl -s https://zrn.co/${RELEASE} |cut -d\" -f2) 
     ISO=$(echo ${URL}| awk -F\/ ' {print $NF}') 
     web_get "${URL}" "${VM_PATH}"
-    #check_hash "${ISO}" "${HASH}"
     make_vm_config "${ISO}"
-
 }
 
 
@@ -946,11 +943,7 @@ function get_popos() {
     check_hash "${ISO}" "${HASH}"
     make_vm_config "${ISO}"
 }
-# https://zrn.co/16core64
-#https://zrn.co/15lite64 -> https://zorin.com/os/download/15/lite/64/
-#https://zrn.co/15lite32 - https://zorin.com/os/download/15/lite/32/
-#(curl -s https://zrn.co/15lite32 |cut -d\" -f2) 
-#
+
 function get_ubuntu() {
     local DEVEL="daily-live"
     local ISO=""


### PR DESCRIPTION
The Zorin iso does optional self-validation on boot it seems, but no sign of a hash to check.
quickemu boots ok but (at least for me ) you need to pick the "safe graphics" options when the installer iso boots or you get a non-working black screen.