### PR TITLE
Fix Windows 11 TPM Device

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -903,9 +903,9 @@ function vm_boot() {
           ${USB_PASSTHROUGH})
   fi
 
-  if [ "${tpm}" == "on" ] && [ -S "${VMDIR}/${VMNAME}-swtpm.sock" ]; then
+  if [ "${tpm}" == "on" ]; then
       # shellcheck disable=SC2054
-      args+=(-chardev socket,id=chrtpm,path="${VMDIR}/${VMNAME}-swtpm.sock"
+      args+=(-chardev socket,id=chrtpm,path="${VMDIR}/${VMNAME}.swtpm-sock"
             -tpmdev emulator,id=tpm0,chardev=chrtpm
             -device tpm-tis,tpmdev=tpm0)
   fi


### PR DESCRIPTION
Two TPM bits were broken causing the VM to be started without a TPM device present. This caused Windows 11 to report incompatible hardware.