### PR TITLE
Garuda support added

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ comprehensive support for macOS and Windows**.
   * [Ubuntu](https://ubuntu.com/desktop) and all the **[official Ubuntu flavours](https://ubuntu.com/download/flavours)**
   * [Fedora](https://getfedora.org/) & openSUSE ([Leap](https://get.opensuse.org/leap/), [Tumbleweed](https://get.opensuse.org/tumbleweed/), [MicroOS](https://microos.opensuse.org/))
   * [Linux Mint](https://linuxmint.com/) (Cinnamon, MATE, and XFCE), [elementary OS](https://elementary.io/), [Pop!_OS](https://pop.system76.com/)
-  * [Arch Linux](https://www.archlinux.org/), [Kali](https://www.kali.org/) & [NixOS](https://nixos.org/)
+  * [Arch Linux](https://www.archlinux.org/), [Kali](https://www.kali.org/),[Garuda](https://garudalinux.org/) & [NixOS](https://nixos.org/)
   * [FreeBSD](https://www.freebsd.org/) & [OpenBSD](https://www.openbsd.org/)
   * Full SPICE support including host/guest clipboard sharing
   * VirtIO-webdavd file sharing for Linux and Windows guests
@@ -171,6 +171,7 @@ preferred flavour.
   * `archlinux`
   * `elementary`
   * `fedora`
+  * `garuda`
   * `kali`
   * `linuxmint-cinnamon`
   * `linuxmint-mate`

--- a/quickget
+++ b/quickget
@@ -657,8 +657,8 @@ EOF
         if [ "${OS}" == "macos" ]; then
             echo "macos_release=\"${RELEASE}\"" >> "${OS}-${RELEASE}.conf"
         fi
-        if [ "${OS}" == "garuda"  ]; then 
-            echo "disk_size=\"32G\"" >> "${OS}-${RELEASE}.conf"  
+        if [ "${OS}" == "garuda"  ]; then
+            echo "disk_size=\"32G\"" >> "${OS}-${RELEASE}.conf"
         fi
 
         # Enable TPM for Windows 11
@@ -1031,8 +1031,8 @@ function get_garuda() {
     local HASH_URL=""
     local GLDL="https://mirrors.fossho.st/garuda/iso"
 
-
     validate_release "releases_garuda"
+
     # Part of the path is different for a couple of community releases vs the supported garuda ones
     case ${RELEASE} in
       mate|cinnamon)
@@ -1040,7 +1040,8 @@ function get_garuda() {
       *)
         REL_TYPE="garuda";;
     esac
-    # need to follow daily releases and use contents of SHA sums file 
+
+    # need to follow daily releases and use contents of SHA sums file
     # to derive the filename and date
     LATEST_URL="${GLDL}/latest/${REL_TYPE}/${RELEASE}/latest.iso.sha256"
     HASH_URL="$(wget -q -O- ${LATEST_URL})"
@@ -1048,8 +1049,9 @@ function get_garuda() {
     HASH=$(echo ${HASH_URL} | cut -d\  -f1)
     LDATE=$(echo "${ISO}" | cut -d'-' -f5|cut -d'.' -f1)
     URL="${GLDL}/${REL_TYPE}/${RELEASE}/${LDATE}"
+
     web_get "${URL}/${ISO}" "${VM_PATH}"
-    # there is a ...iso.zsync but zsync fails ??
+    ### there is a ...iso.zsync but zsync fails ??
     #zsync_get "${URL}/${ISO}" "${VM_PATH}"
     if [ -n $HASH ]; then
       check_hash "${ISO}" "${HASH}"

--- a/quickget
+++ b/quickget
@@ -998,15 +998,15 @@ function get_garuda() {
 
 
     validate_release "releases_garuda"
-
+    # Part of the path is different for a couple of community releases vs the supported garuda ones
     case ${RELEASE} in
       mate|cinnamon)
         REL_TYPE="community";;
       *)
         REL_TYPE="garuda";;
     esac
-    # echo "DEBUG: REL_TYPE=${REL_TYPE}"
-    # echo "DEBUG: GLDL=${GLDL}"
+    # need to follow daily releases and use contents of SHA sums file 
+    # to derive the filename and date
     LATEST_URL="${GLDL}/latest/${REL_TYPE}/${RELEASE}/latest.iso.sha256"
     echo "DEBUG: LATEST_URL=${LATEST_URL}"
     HASH_URL="$(wget -q -O- ${LATEST_URL})"
@@ -1014,10 +1014,6 @@ function get_garuda() {
     HASH=$(echo ${HASH_URL} | cut -d\  -f1)
     LDATE=$(echo "${ISO}" | cut -d'-' -f5|cut -d'.' -f1)
     URL="${GLDL}/${REL_TYPE}/${RELEASE}/${LDATE}"
-    # echo "DEBUG: HASH_URL=${HASH_URL}"
-    # echo "DEBUG: HASH=${HASH}"
-    # echo "DEBUG: ISO=${ISO}"
-    # echo "DEBUG: LDATE=${LDATE}"
     web_get "${URL}/${ISO}" "${VM_PATH}"
     # there is a ...iso.zsync but zsync fails ??
     #zsync_get "${URL}/${ISO}" "${VM_PATH}"

--- a/quickget
+++ b/quickget
@@ -644,6 +644,9 @@ EOF
         if [ "${OS}" == "macos" ]; then
             echo "macos_release=\"${RELEASE}\"" >> "${OS}-${RELEASE}.conf"
         fi
+        if [ "${OS}]" == "garuda"  ]; then 
+            echo "disk_size=\"32G\"" >> "${OS}-${RELEASE}.conf"  
+        fi
 
         # Enable TPM for Windows 11
         if [ "${OS}" == "windows" ] && [ "${RELEASE}" -ge 11 ]; then
@@ -1008,7 +1011,6 @@ function get_garuda() {
     # need to follow daily releases and use contents of SHA sums file 
     # to derive the filename and date
     LATEST_URL="${GLDL}/latest/${REL_TYPE}/${RELEASE}/latest.iso.sha256"
-    echo "DEBUG: LATEST_URL=${LATEST_URL}"
     HASH_URL="$(wget -q -O- ${LATEST_URL})"
     ISO=$(echo ${HASH_URL} | cut -d\  -f2)
     HASH=$(echo ${HASH_URL} | cut -d\  -f1)

--- a/quickget
+++ b/quickget
@@ -1045,15 +1045,15 @@ function get_garuda() {
     # to derive the filename and date
     LATEST_URL="${GLDL}/latest/${REL_TYPE}/${RELEASE}/latest.iso.sha256"
     HASH_URL="$(wget -q -O- ${LATEST_URL})"
-    ISO=$(echo ${HASH_URL} | cut -d\  -f2)
+    ISO="$(echo ${HASH_URL} | awk '{print $NF}' )"
     HASH=$(echo ${HASH_URL} | cut -d\  -f1)
-    LDATE=$(echo "${ISO}" | cut -d'-' -f5|cut -d'.' -f1)
+    LDATE=$(echo "${ISO}" | awk -F'-' '{print $NF}' |cut -d'.' -f1) # 
     URL="${GLDL}/${REL_TYPE}/${RELEASE}/${LDATE}"
 
     web_get "${URL}/${ISO}" "${VM_PATH}"
     ### there is a ...iso.zsync but zsync fails ??
     #zsync_get "${URL}/${ISO}" "${VM_PATH}"
-    if [ -n $HASH ]; then
+    if [ -n "${HASH}" ]; then
       check_hash "${ISO}" "${HASH}"
     fi
     make_vm_config "${ISO}"

--- a/quickget
+++ b/quickget
@@ -38,6 +38,7 @@ function pretty_name() {
     archlinux)          PRETTY_NAME="Arch Linux";;
     elementary)         PRETTY_NAME="elementary OS";;
     freebsd)            PRETTY_NAME="FreeBSD";;
+    garuda)            PRETTY_NAME="Garuda Linux";;
     linuxmint-cinnamon) PRETTY_NAME="Linux Mint Cinnamon";;
     linuxmint-mate)     PRETTY_NAME="Linux Mint MATE";;
     linuxmint-xfce)     PRETTY_NAME="Linux Mint XFCE";;
@@ -130,6 +131,7 @@ function os_support() {
     elementary \
     freebsd \
     fedora \
+    garuda \
     kali \
     kubuntu \
     linuxmint-cinnamon \
@@ -180,6 +182,23 @@ function releases_fedora(){
     echo 33 \
     34 \
     35_beta
+}
+
+function releases_garuda() {
+    echo bspwm \
+    dr460nized \
+    dr460nized-blackarch \
+    dr460nized-gaming \
+    gnome \
+    i3 \
+    kde-barebones \
+    lxqt-kwin \
+    qtile \
+    sway \
+    wayfire \
+    xfce \
+    mate \
+    cinnamon
 }
 
 function releases_kali() {
@@ -578,6 +597,9 @@ function make_vm_config() {
     elif [ "${OS}" == "kali" ]; then
         GUEST="linux"
         IMAGE_TYPE="iso"
+    elif [ "${OS}" == "garuda" ]; then
+        GUEST="linux"
+        IMAGE_TYPE="iso"
     elif [[ "${OS}" == *"linuxmint"* ]]; then
         GUEST="linux"
         IMAGE_TYPE="iso"
@@ -965,6 +987,45 @@ function get_ubuntu() {
         make_vm_config "${ISO}"
     fi
 }
+function get_garuda() {
+    local HASH=""
+    local ISO=""
+    local URL=""
+    local REL_TYPE=""
+    local LATEST_URL=""
+    local HASH_URL=""
+    local GLDL="https://mirrors.fossho.st/garuda/iso"
+
+
+    validate_release "releases_garuda"
+
+    case ${RELEASE} in
+      mate|cinnamon)
+        REL_TYPE="community";;
+      *)
+        REL_TYPE="garuda";;
+    esac
+    # echo "DEBUG: REL_TYPE=${REL_TYPE}"
+    # echo "DEBUG: GLDL=${GLDL}"
+    LATEST_URL="${GLDL}/latest/${REL_TYPE}/${RELEASE}/latest.iso.sha256"
+    echo "DEBUG: LATEST_URL=${LATEST_URL}"
+    HASH_URL="$(wget -q -O- ${LATEST_URL})"
+    ISO=$(echo ${HASH_URL} | cut -d\  -f2)
+    HASH=$(echo ${HASH_URL} | cut -d\  -f1)
+    LDATE=$(echo "${ISO}" | cut -d'-' -f5|cut -d'.' -f1)
+    URL="${GLDL}/${REL_TYPE}/${RELEASE}/${LDATE}"
+    # echo "DEBUG: HASH_URL=${HASH_URL}"
+    # echo "DEBUG: HASH=${HASH}"
+    # echo "DEBUG: ISO=${ISO}"
+    # echo "DEBUG: LDATE=${LDATE}"
+    web_get "${URL}/${ISO}" "${VM_PATH}"
+    # there is a ...iso.zsync but zsync fails ??
+    #zsync_get "${URL}/${ISO}" "${VM_PATH}"
+    if [ -n $HASH ]; then
+      check_hash "${ISO}" "${HASH}"
+    fi
+    make_vm_config "${ISO}"
+}
 
 # Adapted from https://gist.github.com/hongkongkiwi/15a5bf16437315df256c118c163607cb
 function get_windows() {
@@ -1075,6 +1136,8 @@ if [ -n "${2}" ]; then
         get_freebsd
     elif [ "${OS}" == "fedora" ]; then
         get_fedora
+    elif [ "${OS}" == "garuda" ]; then
+        get_garuda
     elif [ "${OS}" == "kali" ]; then
         get_kali
     elif [[ "${OS}" == *"linuxmint-"* ]]; then
@@ -1132,6 +1195,8 @@ else
         releases_freebsd
     elif [ "${OS}" == "fedora" ]; then
         releases_fedora
+    elif [ "${OS}" == "garuda" ]; then
+        releases_garuda
     elif [ "${OS}" == "kali" ]; then
         releases_kali
     elif [[ "${OS}" == *"linuxmint-"* ]]; then

--- a/quickget
+++ b/quickget
@@ -106,6 +106,8 @@ function list_csv() {
         DOWNLOADER="zsync"
       elif [[ "${OS}" == *"ubuntu"* ]] && [ "${RELEASE}" == "devel" ]; then
         DOWNLOADER="zsync"
+      elif [ "${OS}" == "garuda" ]; then
+        DOWNLOADER="zsync"
       else
         DOWNLOADER="wget"
       fi
@@ -1029,7 +1031,7 @@ function get_garuda() {
     local REL_TYPE=""
     local LATEST_URL=""
     local HASH_URL=""
-    local GLDL="https://mirrors.fossho.st/garuda/iso"
+    local GLDL="http://mirrors.fossho.st/garuda/iso"
 
     validate_release "releases_garuda"
 
@@ -1050,13 +1052,12 @@ function get_garuda() {
     LDATE=$(echo "${ISO}" | awk -F'-' '{print $NF}' |cut -d'.' -f1) # 
     URL="${GLDL}/${REL_TYPE}/${RELEASE}/${LDATE}"
 
-    web_get "${URL}/${ISO}" "${VM_PATH}"
-    ### there is a ...iso.zsync but zsync fails ??
-    #zsync_get "${URL}/${ISO}" "${VM_PATH}"
-    if [ -n "${HASH}" ]; then
-      check_hash "${ISO}" "${HASH}"
-    fi
-    make_vm_config "${ISO}"
+    #web_get "${URL}/${ISO}" "${VM_PATH}"
+    zsync_get "${URL}/${ISO}" "${VM_PATH}" "${OS}-${RELEASE}.iso"
+    #if [ -n "${HASH}" ]; then
+    #  check_hash "${ISO}" "${HASH}"
+    #fi
+    make_vm_config "${OS}-${RELEASE}.iso"
 }
 
 # Adapted from https://gist.github.com/hongkongkiwi/15a5bf16437315df256c118c163607cb

--- a/quickget
+++ b/quickget
@@ -657,7 +657,7 @@ EOF
         if [ "${OS}" == "macos" ]; then
             echo "macos_release=\"${RELEASE}\"" >> "${OS}-${RELEASE}.conf"
         fi
-        if [ "${OS}]" == "garuda"  ]; then 
+        if [ "${OS}" == "garuda"  ]; then 
             echo "disk_size=\"32G\"" >> "${OS}-${RELEASE}.conf"  
         fi
 


### PR DESCRIPTION
Yet another set of rolling releases with a slightly convoluted method to resolve the file name.
The mirrors have a .zsync file so updated to use zsync
Supports the current set of "flavours": ( ticks have been installed )

- [ ] bspwm 
- [x] dr460nized 
- [x] dr460nized-blackarch 
- [ ] dr460nized-gaming 
- [ ] gnome 
- [x] i3 
- [x] kde-barebones 
- [x] lxqt-kwin ( see [this](https://github.com/philclifford/quickemu/issues/6) )
- [ ] qtile 
- [x] sway 
- [ ] wayfire 
- [ ] xfce 
- [x] mate
- [ ] cinnamon
