### PR TITLE
Fedora 35 released

### DIFF
--- a/quickget
+++ b/quickget
@@ -181,7 +181,7 @@ function releases_freebsd(){
 function releases_fedora(){
     echo 33 \
     34 \
-    35_beta
+    35
 }
 
 function releases_kali() {


### PR DESCRIPTION
fix #199

code for beta left so when 36 beta appears just need to add it to the release list