### PR TITLE
OVMF path for Gentoo

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -396,7 +396,7 @@ function vm_boot() {
           EFI_CODE="/usr/share/OVMF/x64/OVMF_CODE.fd"
           efi_vars "/usr/share/OVMF/x64/OVMF_VARS.fd" "${EFI_VARS}"
         elif [ -e "/usr/share/edk2-ovmf/OVMF_CODE.fd" ]; then
-	        EFI_CODE="/usr/share/edk2-ovmf/OVMF_CODE.secboot.fd"
+	        EFI_CODE="/usr/share/edk2-ovmf/OVMF_CODE.fd"
 	        efi_vars "/usr/share/edk2-ovmf/OVMF_VARS.fd" "${EFI_VARS}"
         else
           echo "ERROR! EFI boot requested but no EFI firmware found."


### PR DESCRIPTION
Adding OVMF paths for Gentoo users.

Taken from package:
*  sys-firmware/edk2-ovmf
      Latest version available: 202105-r1
      Latest version installed: 202105-r1
      Size of files: 2,573 KiB
      Homepage:      https://github.com/tianocore/edk2
      Description:   UEFI firmware for 64-bit x86 virtual machines
      License:       BSD-2 MIT

 * Contents of sys-firmware/edk2-ovmf-202105-r1:
/usr
/usr/share
/usr/share/doc
/usr/share/doc/edk2-ovmf-202105-r1
/usr/share/doc/edk2-ovmf-202105-r1/README.gentoo.bz2
/usr/share/edk2-ovmf
/usr/share/edk2-ovmf/EnrollDefaultKeys.efi
/usr/share/edk2-ovmf/OVMF_CODE.fd
/usr/share/edk2-ovmf/OVMF_CODE.secboot.fd
/usr/share/edk2-ovmf/OVMF_VARS.fd
/usr/share/edk2-ovmf/Shell.efi
/usr/share/edk2-ovmf/UefiShell.img
/usr/share/qemu
/usr/share/qemu/firmware
/usr/share/qemu/firmware/40-edk2-ovmf-x64-sb-enrolled.json
/usr/share/qemu/firmware/50-edk2-ovmf-x64-sb.json
/usr/share/qemu/firmware/60-edk2-ovmf-x64.json
