### PR TITLE
nasty version hack for quickget

### DIFF
--- a/quickget
+++ b/quickget
@@ -1084,6 +1084,10 @@ if [ -n "${1}" ]; then
         list_csv
     elif [ "${OS}" == "list_json" ]; then
         list_json
+    elif [ "${OS}" == "--version" ] || [ "${OS}" == "-version" ] || [ "${OS}" == "version" ]; then
+      quickemu_version=$( ./quickemu --version)
+      echo "Quickemu Version: ${quickemu_version}"
+      exit 0 
     fi
 else
     echo "ERROR! You must specify an operating system:"

--- a/quickget
+++ b/quickget
@@ -1085,7 +1085,8 @@ if [ -n "${1}" ]; then
     elif [ "${OS}" == "list_json" ]; then
         list_json
     elif [ "${OS}" == "--version" ] || [ "${OS}" == "-version" ] || [ "${OS}" == "version" ]; then
-      quickemu_version=$( ./quickemu --version)
+      whereIam=$(dirname "${BASH_SOURCE[0]}") 
+      quickemu_version=$( ${whereIam}/quickemu --version)
       echo "Quickemu Version: ${quickemu_version}"
       exit 0 
     fi


### PR DESCRIPTION
fixes #204 
fix as in slightly dirty hack - but since quickget parameter handling is deliberately minimal at the moment, and it doesn't have its own version (yet?) this PR just catches "version" as OS (with up to 2 dashes) and goes gets the quickemu version.
:shrug: 