### PR TITLE
Add KDE Neon to quickget

### DIFF
--- a/quickget
+++ b/quickget
@@ -38,6 +38,7 @@ function pretty_name() {
     archlinux)          PRETTY_NAME="Arch Linux";;
     elementary)         PRETTY_NAME="elementary OS";;
     freebsd)            PRETTY_NAME="FreeBSD";;
+    kdeneon)           PRETTY_NAME="KDE Neon";;
     linuxmint-cinnamon) PRETTY_NAME="Linux Mint Cinnamon";;
     linuxmint-mate)     PRETTY_NAME="Linux Mint MATE";;
     linuxmint-xfce)     PRETTY_NAME="Linux Mint XFCE";;
@@ -132,6 +133,7 @@ function os_support() {
     freebsd \
     fedora \
     kali \
+    kdeneon \
     kubuntu \
     linuxmint-cinnamon \
     linuxmint-mate \
@@ -187,6 +189,13 @@ function releases_fedora(){
 function releases_kali() {
     echo latest \
     weekly
+}
+
+function releases_kdeneon() {
+    echo user \
+    testing \
+    unstable \
+    developer
 }
 
 function releases_linuxmint(){
@@ -588,6 +597,9 @@ function make_vm_config() {
     elif [ "${OS}" == "kali" ]; then
         GUEST="linux"
         IMAGE_TYPE="iso"
+    elif [ "${OS}" == "kdeneon" ]; then
+        GUEST="linux"
+        IMAGE_TYPE="iso"
     elif [[ "${OS}" == *"linuxmint"* ]]; then
         GUEST="linux"
         IMAGE_TYPE="iso"
@@ -768,6 +780,21 @@ function get_kali() {
     HASH=$(wget -q -O- "https://cdimage.kali.org/${SUBDIR}/SHA256SUMS" | grep "${ISO}" | cut -d' ' -f1)
     URL="https://cdimage.kali.org/${SUBDIR}/${ISO}"
     web_get "${URL}" "${VM_PATH}"
+    check_hash "${ISO}" "${HASH}"
+    make_vm_config "${ISO}"
+}
+
+function get_kdeneon() {
+    local HASH=""
+    local ISO=""
+    local URL=""
+
+    validate_release "releases_kdeneon"
+    
+    ISO="neon-${RELEASE}-current.iso"
+    URL="https://files.kde.org/neon/images/${RELEASE}/current/${ISO}"
+    zsync_get "${URL}" "${VM_PATH}"
+    HASH=$(wget -q -O- "https://files.kde.org/neon/images/${RELEASE}/current/neon-${RELEASE}-current.sha256sum" | cut -d' ' -f1)
     check_hash "${ISO}" "${HASH}"
     make_vm_config "${ISO}"
 }
@@ -1109,6 +1136,8 @@ if [ -n "${2}" ]; then
         get_fedora
     elif [ "${OS}" == "kali" ]; then
         get_kali
+    elif [ "${OS}" == "kdeneon" ]; then
+        get_kdeneon
     elif [[ "${OS}" == *"linuxmint-"* ]]; then
         get_linuxmint
     elif [[ "${OS}" == *"nixos-"* ]]; then

--- a/quickget
+++ b/quickget
@@ -785,17 +785,16 @@ function get_kali() {
 }
 
 function get_kdeneon() {
-    local HASH=""
     local ISO=""
     local URL=""
 
     validate_release "releases_kdeneon"
-    
     ISO="neon-${RELEASE}-current.iso"
-    URL="https://files.kde.org/neon/images/${RELEASE}/current/${ISO}"
-    zsync_get "${URL}" "${VM_PATH}"
-    HASH=$(wget -q -O- "https://files.kde.org/neon/images/${RELEASE}/current/neon-${RELEASE}-current.sha256sum" | cut -d' ' -f1)
-    check_hash "${ISO}" "${HASH}"
+    # Get the URL of the mirror closest to the user's location
+    URL=$(wget -q -O- "https://files.kde.org/neon/images/${RELEASE}/current/neon-${RELEASE}-current.iso.zsync.mirrorlist" | \
+          grep "neon-${RELEASE}-current.iso.zsync" | grep '>1.<' | cut -d\" -f 6 | sed 's/https/http/g' | xargs dirname)
+    zsync_get "${URL}/${ISO}" "${VM_PATH}"
+    check_hash "${ISO}" "$(wget -q -O- "https://files.kde.org/neon/images/${RELEASE}/current/neon-${RELEASE}-current.sha256sum" | cut -d' ' -f1)"
     make_vm_config "${ISO}"
 }
 


### PR DESCRIPTION
[KDE Neon](https://neon.kde.org) follows a rolling release model and provides several editions, each with a different level of testing vs stability (Unstable, Testing and User Edition).
On top, there is also a Developer Edition (Unstable plus some dev tools and libs preinstalled).

The reason I file this PR as a draft, is that I need help getting `zsync` to work. All files are located under https://files.kde.org/neon/images/user/current/ (replace "user" with the desired edition).
According to the `zsync` README in this directory, `files.kde.org` will always force a `https` connection, making it unusable for downloads with `zsync`. Instead, they suggest using a mirror - there is a nice webpage that shows you the nearest one at https://files.kde.org/neon/images/user/current/neon-user-current.iso.zsync.mirrorlist.

That's where I need help: Is there a way to parse this mirrorlist webpage in order to get the best mirror for the user's location? I could just hardcode to use one single mirror, but that would defeat the purpose of using mirrors in the first place.

I would be grateful for comments or PRs to my branch (`daPhipz/add-kde-neon`). Thanks!