### PR TITLE
USB2 guest fixes - tested on Catalina, spice, Intel

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -241,7 +241,7 @@ function vm_boot() {
   HOST_CPU_VENDOR=$(lscpu | grep -E 'Vendor' | cut -d':' -f2 | sed 's/ //g')
 
   # A CPU with Intel VT-x / AMD SVM support is required
-  if [ "${HOST_CPU_VENDOR}" == "AuthenticIntel" ]; then
+  if [ "${HOST_CPU_VENDOR}" == "GenuineIntel" ]; then
     if ! check_cpu_flag vmx; then
       echo "ERROR! Intel VT-x support is required."
       exit 1
@@ -449,7 +449,7 @@ function vm_boot() {
       # A CPU with SSE4.1 support is required for >= macOS Sierra
       if check_cpu_flag sse4_1; then
         case ${HOST_CPU_VENDOR} in
-          AuthenticIntel)
+          GenuineIntel)
             CPU="-cpu host,kvm=on,vendor=GenuineIntel,+hypervisor,+invtsc,+kvm_pv_eoi,+kvm_pv_unhalt";;
           AuthenticAMD|*)
             # Used in past versions: +movbe,+smep,+xgetbv1,+xsavec,+avx2
@@ -493,6 +493,10 @@ function vm_boot() {
       GUEST_TWEAKS="-device isa-applesmc,osk=${OSK} -no-hpet -global kvm-pit.lost_tick_policy=discard"
       if [ -z "${disk_size}" ]; then
         disk_size="96G"
+      fi
+      # fixme: spice problems with usb-tablet
+      if [ "${OUTPUT}" == "none" ]; then
+        MOUSE="usb-mouse"
       fi
       ;;
     windows)
@@ -894,19 +898,39 @@ function vm_boot() {
   fi
 
   # shellcheck disable=SC2054,SC2206
-  args+=(-device ${USB_HOST_PASSTHROUGH_CONTROLLER},id=spicepass
-         -chardev spicevmc,id=usbredirchardev1,name=usbredir
-         -device usb-redir,chardev=usbredirchardev1,id=usbredirdev1
-         -chardev spicevmc,id=usbredirchardev2,name=usbredir
-         -device usb-redir,chardev=usbredirchardev2,id=usbredirdev2
-         -chardev spicevmc,id=usbredirchardev3,name=usbredir
-         -device usb-redir,chardev=usbredirchardev3,id=usbredirdev3
-         -device usb-ccid
-         -chardev spicevmc,id=ccid,name=smartcard
-         -device ccid-card-passthru,chardev=ccid
-         -device virtio-serial-pci
-         -chardev spiceport,id=webdav0,name=org.spice-space.webdav.0
-         -device virtserialport,chardev=webdav0,name=org.spice-space.webdav.0)
+  if [ "${USB_HOST_PASSTHROUGH_CONTROLLER}" == "qemu-xhci" ]; then
+    args+=(-device ${USB_HOST_PASSTHROUGH_CONTROLLER},id=spicepass
+           -chardev spicevmc,id=usbredirchardev1,name=usbredir
+           -device usb-redir,chardev=usbredirchardev1,id=usbredirdev1
+           -chardev spicevmc,id=usbredirchardev2,name=usbredir
+           -device usb-redir,chardev=usbredirchardev2,id=usbredirdev2
+           -chardev spicevmc,id=usbredirchardev3,name=usbredir
+           -device usb-redir,chardev=usbredirchardev3,id=usbredirdev3
+           -device usb-ccid
+           -chardev spicevmc,id=ccid,name=smartcard
+           -device ccid-card-passthru,chardev=ccid
+           -device virtio-serial-pci
+           -chardev spiceport,id=webdav0,name=org.spice-space.webdav.0
+           -device virtserialport,chardev=webdav0,name=org.spice-space.webdav.0)
+  else
+    # https://www.spice-space.org/usbredir.html
+    args+=(-device ich9-usb-ehci1,id=usb
+           -device ich9-usb-uhci1,masterbus=usb.0,firstport=0,multifunction=on
+           -device ich9-usb-uhci2,masterbus=usb.0,firstport=2
+           -device ich9-usb-uhci3,masterbus=usb.0,firstport=4
+           -chardev spicevmc,name=usbredir,id=usbredirchardev1
+           -device usb-redir,chardev=usbredirchardev1,id=usbredirdev1
+           -chardev spicevmc,name=usbredir,id=usbredirchardev2
+           -device usb-redir,chardev=usbredirchardev2,id=usbredirdev2
+           -chardev spicevmc,name=usbredir,id=usbredirchardev3
+           -device usb-redir,chardev=usbredirchardev3,id=usbredirdev3
+           -device usb-ccid
+           -chardev spicevmc,id=ccid,name=smartcard
+           -device ccid-card-passthru,chardev=ccid
+           -device virtio-serial-pci
+           -chardev spiceport,id=webdav0,name=org.spice-space.webdav.0
+           -device virtserialport,chardev=webdav0,name=org.spice-space.webdav.0)
+  fi
 
   # https://wiki.qemu.org/Documentation/9psetup
   # https://askubuntu.com/questions/772784/9p-libvirt-qemu-share-modes

--- a/quickemu
+++ b/quickemu
@@ -893,22 +893,20 @@ function vm_boot() {
            -drive id=SystemDisk,if=none,format=qcow2,file="${disk_img}" ${STATUS_QUO})
   fi
 
-  if [ "${guest_os}" != "macos" ]; then
-    # shellcheck disable=SC2054,SC2206
-    args+=(-device ${USB_HOST_PASSTHROUGH_CONTROLLER},id=spicepass
-           -chardev spicevmc,id=usbredirchardev1,name=usbredir
-           -device usb-redir,chardev=usbredirchardev1,id=usbredirdev1
-           -chardev spicevmc,id=usbredirchardev2,name=usbredir
-           -device usb-redir,chardev=usbredirchardev2,id=usbredirdev2
-           -chardev spicevmc,id=usbredirchardev3,name=usbredir
-           -device usb-redir,chardev=usbredirchardev3,id=usbredirdev3
-           -device usb-ccid
-           -chardev spicevmc,id=ccid,name=smartcard
-           -device ccid-card-passthru,chardev=ccid
-           -device virtio-serial-pci
-           -chardev spiceport,id=webdav0,name=org.spice-space.webdav.0
-           -device virtserialport,chardev=webdav0,name=org.spice-space.webdav.0)
-  fi
+  # shellcheck disable=SC2054,SC2206
+  args+=(-device ${USB_HOST_PASSTHROUGH_CONTROLLER},id=spicepass
+         -chardev spicevmc,id=usbredirchardev1,name=usbredir
+         -device usb-redir,chardev=usbredirchardev1,id=usbredirdev1
+         -chardev spicevmc,id=usbredirchardev2,name=usbredir
+         -device usb-redir,chardev=usbredirchardev2,id=usbredirdev2
+         -chardev spicevmc,id=usbredirchardev3,name=usbredir
+         -device usb-redir,chardev=usbredirchardev3,id=usbredirdev3
+         -device usb-ccid
+         -chardev spicevmc,id=ccid,name=smartcard
+         -device ccid-card-passthru,chardev=ccid
+         -device virtio-serial-pci
+         -chardev spiceport,id=webdav0,name=org.spice-space.webdav.0
+         -device virtserialport,chardev=webdav0,name=org.spice-space.webdav.0)
 
   # https://wiki.qemu.org/Documentation/9psetup
   # https://askubuntu.com/questions/772784/9p-libvirt-qemu-share-modes

--- a/quickemu
+++ b/quickemu
@@ -739,7 +739,7 @@ function vm_boot() {
     else
       echo "spice,${SPICE_PORT}" >> "${VMDIR}/${VMNAME}.ports"
       echo -n " - SPICE:    On host:  spicy --title \"${VMNAME}\" --port ${SPICE_PORT}"
-      if [ "${guest_os}" != "macos" ] && [ -n "${PUBLIC}" ]; then
+      if [ -n "${PUBLIC}" ]; then
         echo -n " --spice-shared-dir ${PUBLIC}"
       fi
       echo "${FULLSPICY}"
@@ -749,6 +749,9 @@ function vm_boot() {
     # Reference: https://gitlab.gnome.org/GNOME/phodav/-/issues/5
     if [ "${guest_os}" != "macos" ] && [ -n "${PUBLIC}" ]; then
       echo " - WebDAV:   On guest: dav://localhost:9843/"
+    else
+      echo " - WebDAV:   On guest: build spice-webdavd (https://gitlab.gnome.org/GNOME/phodav/-/merge_requests/24)
+      echo " - WebDAV:   On guest: Finder>Connect to Server>http://localhost:9843/"
     fi
   fi
 

--- a/quickemu
+++ b/quickemu
@@ -750,7 +750,7 @@ function vm_boot() {
     if [ "${guest_os}" != "macos" ] && [ -n "${PUBLIC}" ]; then
       echo " - WebDAV:   On guest: dav://localhost:9843/"
     else
-      echo " - WebDAV:   On guest: build spice-webdavd (https://gitlab.gnome.org/GNOME/phodav/-/merge_requests/24)
+      echo " - WebDAV:   On guest: build spice-webdavd (https://gitlab.gnome.org/GNOME/phodav/-/merge_requests/24)"
       echo " - WebDAV:   On guest: Finder>Connect to Server>http://localhost:9843/"
     fi
   fi

--- a/quickemu
+++ b/quickemu
@@ -494,7 +494,9 @@ function vm_boot() {
       if [ -z "${disk_size}" ]; then
         disk_size="96G"
       fi
-      # fixme: spice problems with usb-tablet
+      # fixme: spice problems with usb-tablet - can't move mouse, clicks work
+      # working https://raw.githubusercontent.com/kholia/OSX-KVM/1cc6430f96b452cb78b9a079c34bb9933144ce18/macOS-libvirt-Catalina.xml
+      # https://github.com/wimpysworld/quickemu/issues/222
       if [ "${OUTPUT}" == "none" ]; then
         MOUSE="usb-mouse"
       fi


### PR DESCRIPTION
- fixes for usb/redirection for USB2 guests, uhci is needed for low speed devices.
- I've tested with Catalina. I'm not sure if any other guests have USB3 problems
- Mouse workaround for spice remote viewer/macos
- AuthenticIntel looks like a typo - if not then old Intels show `GenuineIntel` 
