### PR TITLE
png != svg. Causes 404 for image urls

### DIFF
--- a/quickget
+++ b/quickget
@@ -114,7 +114,7 @@ function list_csv() {
       FUNC="${OS}"
     fi
     PNG="https://quickemu-project.github.io/quickemu-icons/png/${FUNC}/${FUNC}-quickemu-white-pinkbg.png"
-    SVG="https://quickemu-project.github.io/quickemu-icons/png/${FUNC}/${FUNC}-quickemu-white-pinkbg.svg"
+    SVG="https://quickemu-project.github.io/quickemu-icons/svg/${FUNC}/${FUNC}-quickemu-white-pinkbg.svg"
 
 
     for RELEASE in $("releases_${FUNC}"); do


### PR DESCRIPTION
While talking with @ymauray we noticed that the `.svg` request was using the `png` path causing a 404.