### PR TITLE
fix: add dependency on new qemu-system-modules-spice for noble onwards

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,6 +22,7 @@ Depends:
  procps,
  python3-minimal,
  qemu-system (>= 6.0),
+ base-files (<< 13~) | qemu-system-modules-spice,
  socat,
  spice-client-gtk,
  swtpm,


### PR DESCRIPTION
# Description

Adds a dependency for noble and later on the `qemu-system-modules-spice` package

<!-- Close any related issues. Delete if not relevant -->

- Closes #1694

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Packaging (updates the packaging)

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have tested my code in common scenarios and confirmed there are no regressions
