### PR TITLE
refactor(windows): don't install usbdk

### DIFF
--- a/quickget
+++ b/quickget
@@ -3016,19 +3016,14 @@ function unattended_windows() {
           <Order>2</Order>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
-          <CommandLine>msiexec /i F:\UsbDk_1.0.22_x64.msi /quiet /passive /qn</CommandLine>
-          <Description>Install usbdk USB sharing agent</Description>
-          <Order>3</Order>
-        </SynchronousCommand>
-        <SynchronousCommand wcm:action="add">
           <CommandLine>msiexec /i F:\spice-vdagent-x64-0.10.0.msi /quiet /passive /qn</CommandLine>
           <Description>Install spice-vdagent SPICE agent</Description>
-          <Order>4</Order>
+          <Order>3</Order>
         </SynchronousCommand>
         <SynchronousCommand wcm:action="add">
           <CommandLine>Cmd /c POWERCFG -H OFF</CommandLine>
           <Description>Disable Hibernation</Description>
-          <Order>5</Order>
+          <Order>4</Order>
         </SynchronousCommand>
       </FirstLogonCommands>
     </component>
@@ -3040,7 +3035,6 @@ EOF
 echo "Downloading Spice drivers..."
 web_get https://www.spice-space.org/download/windows/spice-webdavd/spice-webdavd-x64-latest.msi "${VM_PATH}/unattended"
 web_get https://www.spice-space.org/download/windows/vdagent/vdagent-win-0.10.0/spice-vdagent-x64-0.10.0.msi "${VM_PATH}/unattended"
-web_get https://www.spice-space.org/download/windows/usbdk/UsbDk_1.0.22_x64.msi "${VM_PATH}/unattended"
 
 echo "Making unattended.iso"
 mkisofs -quiet -J -o "${VM_PATH}/unattended.iso" "${VM_PATH}/unattended/"


### PR DESCRIPTION
# Description

This PR removes UsbDk from `unattended.iso`, as it is not needed inside the guest (to my knowledge, it is only required on Windows-based hosts).

I tested this change on both Windows 10 22H2 and Windows 11 23H2. I can't test it on 24H2 at the moment due to #1475, but I believe this change should be fine for more recent releases of Windows 11 as well. 

- Resolves #1627 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
