### PR TITLE
fix: Support 4M qcow2 images

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -733,7 +733,7 @@ function configure_bios() {
             # Write destination vars file with correct extension
             # based on source format of the EFI_EXTRA_VARS file
             QCOW2VARS=$(is_firmware_qcow2 "${EFI_EXTRA_VARS}")
-            if ["${QCOW2VARS}" = "true"]; then
+            if [ "${QCOW2VARS}" = "true" ]; then
                 EFI_VARS="${VMDIR}/OVMF_VARS.qcow2"
             else
                 EFI_VARS="${VMDIR}/OVMF_VARS.fd"
@@ -1393,8 +1393,8 @@ function vm_boot() {
     if [[ "${boot}" == *"efi"* ]]; then
         QCOW2CODE=$(is_firmware_qcow2 "${EFI_CODE}")
         QCOW2VARS=$(is_firmware_qcow2 "${EFI_VARS}")
-        if ["${QCOW2CODE}" = "true"]; then EFI_CODE_FORMAT="qcow2"; else EFI_CODE_FORMAT="raw"; fi
-        if ["${QCOW2VARS}" = "true"]; then EFI_VARS_FORMAT="qcow2"; else EFI_VARS_FORMAT="raw"; fi
+        if [ "${QCOW2CODE}" = "true" ]; then EFI_CODE_FORMAT="qcow2"; else EFI_CODE_FORMAT="raw"; fi
+        if [ "${QCOW2VARS}" = "true" ]; then EFI_VARS_FORMAT="qcow2"; else EFI_VARS_FORMAT="raw"; fi
         # shellcheck disable=SC2054
         args+=(-global driver=cfi.pflash01,property=secure,value=on
             -drive if=pflash,format="${EFI_CODE_FORMAT}",unit=0,file="${EFI_CODE}",readonly=on


### PR DESCRIPTION
# Description

This is a draft PR to add support for using EFI firmware in qcow2 format.

Merging this PR allows Quickemu to keep up with the modern approach taken by distributions like Fedora which have retired raw versions of the 4M firmware images in their `edk2` package in favour of only shipping qcow2 versions.

This approach is unlikely to be reverted. I asked one of the maintainers about this and was told:

> The advantage of using qcow2 is that you save memory with sparse flash images.  That is important on arm, where the flash has a fixed size of 2x 64M and only a small fraction is actually used.  x64 has been switched over too for consistency.

So since it does not appear that this approach will go away, and other distros will likely follow suit, it makes sense for Quickemu to update to handle this situation.

This allows Quickemu to launch Windows 11 VMs (and others) with support for full Secure Boot, and a **functional** vTPM, providing Standard Hardware Security support on distros which ship qcow2 4M firmware (Fedora). This did already work on distros shipping 4M raw firmware images like Debian/Ubuntu, but they are likely to go in the direction of Fedora eventually.

Win 11 booted on Fedora 43 from the `quickemu` package, using a default config generated by `quickget`:

<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/02d872e4-9ae7-4499-85c4-76650502b53a" />

- Closes #1747

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Packaging (updates the packaging)
- [ ] Documentation (updates the documentation)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections

