### PR TITLE
fix: don't crash if public dir does not exist

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -1803,6 +1803,7 @@ function fileshare_param_check() {
 
         if [ ! -d "${PUBLIC}" ]; then
             echo " - WARNING! Public directory: '${PUBLIC}' doesn't exist!"
+            PUBLIC=""
         else
             PUBLIC_TAG="Public-${USER,,}"
             PUBLIC_PERMS=$(${STAT}  -c "%A" "${PUBLIC}")


### PR DESCRIPTION

# Description

On my machine, I do not have a `~/Public` directory, which causes quickqemu to spit out a warning and then crash:

```console
$ quickemu --vm vm.conf
 - WARNING! Public directory: '/home/jeremy/Public' doesn't exist!
Quickemu 4.9.7 using /nix/store/nk59c14nwf79bafmrsnnhndmpnrlplrv-qemu-10.1.0/bin/qemu-system-x86_64 v10.1.0
...
 - 9P:       On guest: sudo mount -t 9p -o trans=virtio,version=9p2000.L,msize=104857600  ~/Public
...
 - Process:  ERROR! Failed to start /nix/store/va3md6gv82fqf7pxbfxd0cd5gfnmnz9f-vm.conf as va3md6gv82fqf7pxbfxd0cd5gfnmnz9f-vm

qemu-system-x86_64: -netdev user,hostname=va3md6gv82fqf7pxbfxd0cd5gfnmnz9f-vm,hostfwd=tcp::22220-:22,smb=/home/jeremy/Public,id=nic: Error accessing shared directory '/home/jeremy/Public': No such file or directory
```

Here's my `vm.conf`. Note how I'm not asking for a public dir:

```
iso="/nix/store/q3j8357dz3kmyjv84wfj4pyn20b65h9l-nixos-minimal-25.11pre-git-x86_64-linux.iso/iso/nixos-minimal-25.11pre-git-x86_64-linux.iso"
```

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
