### PR TITLE
fix: URL of openSUSE Leap 16.0 ISO URL

### DIFF
--- a/quickget
+++ b/quickget
@@ -2317,7 +2317,7 @@ function get_opensuse() {
         ISO="openSUSE-Leap-${RELEASE}-DVD-x86_64.iso"
         URL="https://download.opensuse.org/distribution/leap/${RELEASE}/iso"
     elif [ "${RELEASE}" == 16.0 ]; then
-        ISO="Leap-${RELEASE}-online-installer-x86_64.install.iso"
+        ISO="Leap-${RELEASE}-offline-installer-x86_64.install.iso"
         URL="https://download.opensuse.org/distribution/leap/${RELEASE}/offline"
     else
         ISO="openSUSE-Leap-${RELEASE}-DVD-x86_64-Current.iso"


### PR DESCRIPTION
The fallback else case doesn't work for OpenSUSE Leap 16.

# Description

Please include a summary of the changes along with any relevant motivation and context.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Packaging (updates the packaging)
- [ ] Documentation (updates the documentation)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections