### PR TITLE
fix: Use a portable grep option

### DIFF
--- a/quickget
+++ b/quickget
@@ -929,7 +929,7 @@ function editions_parrotsec() {
 
 function releases_pclinuxos() {
 # shellcheck disable=SC2046
-    echo $(web_pipe "https://ftp.fau.de/pclinuxos/pclinuxos/iso" | grep -oP 'pclinuxos64-\K[^\-]+-\K[0-9]+\.[0-9]+' | head -n 1)
+    echo $(web_pipe "https://ftp.fau.de/pclinuxos/pclinuxos/iso" | grep -o -E 'pclinuxos64-([a-z]+-)+[0-9]{4}\.[0-9]{2}\.iso'| grep -o -E '[0-9]{4}\.[0-9]{2}'| head -n 1)
 }
 
 function editions_pclinuxos() {


### PR DESCRIPTION
# Description

A GNU-flavoured option for `grep` in the `releases_pclinuxos()` function caused an error mentioned in #1713.

```
❯ quickget --list
grep: invalid option -- P
usage: grep [-abcdDEFGHhIiJLlMmnOopqRSsUVvwXxZz] [-A num] [-B num] [-C[num]]
        [-e pattern] [-f file] [--binary-files=value] [--color=when]
        [--context[=num]] [--directories=action] [--label] [--line-buffered]
        [--null] [pattern] [file ...]
```

As long as it is the only place in the codebase where the `-P` option was used, I decided to rework the command that caused the issue in a portable way.

- Fixes #1713

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions