### PR TITLE
fix(nix): glxinfo has been renamed mesa-demos

### DIFF
--- a/devshell.nix
+++ b/devshell.nix
@@ -26,7 +26,7 @@ mkShell {
     OVMF
     OVMFFull
   ] ++ lib.optionals stdenv.isLinux [
-    glxinfo
+    mesa-demos
     usbutils
     xdg-user-dirs
   ]);

--- a/package.nix
+++ b/package.nix
@@ -7,10 +7,10 @@
 , cdrtools
 , curl
 , gawk
-, glxinfo
 , gnugrep
 , gnused
 , jq
+, mesa-demos
 , pciutils
 , procps
 , python3
@@ -51,7 +51,7 @@ let
     OVMF
     OVMFFull
   ] ++ lib.optionals stdenv.isLinux [
-    glxinfo
+    mesa-demos
     usbutils
     xdg-user-dirs
   ];


### PR DESCRIPTION
The nix package was renamed, but binary stays the same

# Description

Please include a summary of the changes along with any relevant motivation and context.

<!-- Close any related issues. Delete if not relevant -->

- Closes #1763 


## Type of change

<!-- Delete any that are not relevant -->
- [x] Packaging (updates the packaging)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions

