### PR TITLE
refactor(firmware): use od to read qcow2 magic bytes

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -625,8 +625,11 @@ function configure_ram() {
 
 function is_firmware_qcow2() {
     # Check for the magic bytes that indicate the firmware is in qcow2 format,
-    # otherwise default to assuming firmware files are in raw format
-    [ "$(head -c 4 "$1")" = "QFI"$'\xfb' ] && echo "true" || echo "false"
+    # otherwise default to assuming firmware files are in raw format.
+    # Use od to read bytes as hex to avoid null byte warnings in command substitution.
+    local magic
+    magic=$(od -An -tx1 -N4 "$1" 2>/dev/null | tr -d ' ')
+    [ "$magic" = "514649fb" ] && echo "true" || echo "false"
 }
 
 function configure_bios() {


### PR DESCRIPTION
- Replace head-based check with od -tx1 to read first 4 bytes as hex
- Compare hex string to 514649fb to detect qcow2 reliably
- Avoid null-byte warnings from command substitution; keep same true/false output

Fixes #1796

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code