### PR TITLE
fix(public_dir): respect public_dir setting when loading VM

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -2214,6 +2214,7 @@ fi
 if [ -n "${VM}" ] && [ -e "${VM}" ]; then
     # shellcheck source=/dev/null
     source "${VM}"
+    PUBLIC="${public_dir:-${PUBLIC}}"
 
     VMDIR=$(dirname "${disk_img}")          # directory the VM disk and state files are stored
     VMNAME=$(basename "${VM}" .conf)        # name of the VM


### PR DESCRIPTION
- Read public_dir from the sourced VM config into PUBLIC
- Preserve existing PUBLIC when public_dir is not set
- Prevent PUBLIC being empty when a VM specifies public_dir

Fixes #1634

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code