### PR TITLE
fix(quickget): resolve failing ISO downloads

### DIFF
--- a/quickget
+++ b/quickget
@@ -708,7 +708,7 @@ function editions_endless() {
 
 function releases_fedora() {
     #shellcheck disable=SC2046,SC2005
-    # Filter out EOL releases (41 and earlier)
+    # Filter out EOL release 41
     echo $(web_pipe "https://getfedora.org/releases.json" | jq -r 'map(.version) | unique | .[]' | sed 's/ /_/g' | sort -r | grep -v '^41$')
 }
 
@@ -1152,10 +1152,11 @@ function releases_zorin() {
 
 function editions_zorin() {
     # Lite edition not available for Zorin 18 (Pro-only starting from 18)
-    if [ "${RELEASE}" = "18" ]; then
-        echo core64 education64
-    else
+    # When RELEASE is unset (e.g. csv_data context), return all editions
+    if [ -z "${RELEASE}" ] || [ "${RELEASE}" != "18" ]; then
         echo core64 lite64 education64
+    else
+        echo core64 education64
     fi
 }
 


### PR DESCRIPTION
## Summary

Fix multiple failing ISO download rules in scripts/quickget. This PR updates edition parsing, ISO naming patterns, mirror selection and removes unavailable/discontinued entries so quickget no longer produces broken download links.

## Distros fixed and what was wrong

- Solus (Xfce beta): handle older "beta" naming that prevented matching older releases
- Zorin OS: switch to updated download method and correct available editions
- PCLinuxOS: dynamically discover edition release listings instead of relying on static names
- Parrot Security: update releases and edition identifiers to match current site layout
- Garuda Linux: update editions and naming patterns
- MX Linux (Xfce): correct ISO filename pattern for current releases
- Artix Linux: fix editions parsing so editions are listed correctly
- Athena OS: update ISO naming for v23.11+ releases
- Guix: update release versions to 1.5.0 and 1.4.0
- Debian: only list archive versions which actually provide live images (avoid non-downloadable entries)
- Gentoo, Linux Mint, LMDE: prefer mirrors.kernel.org as reliable mirror provider

## Removed / discontinued

- KolibriOS: remove Italian locale (locale ISO unavailable)
- KDE Neon: remove discontinued developer edition
- General: exclude EOL and pre-release distro versions to avoid broken links and transient failures

## Changes

- Update scripts/quickget with parsing, naming and mirror fixes
- Remove unavailable editions/locales from quickget data
- CI: improve test-quickget workflows and test formatting to validate distro table generation

## Testing

- CI: test-quickget workflow was split and updated; tests now collect distro rows to a temp file for stable sorting and use wc -l to count results
- Manual: validated quickget output locally for the affected distros and confirmed generated download URLs resolve

## Notes

The PR focuses only on quickget fixes; other unrelated commits on the branch are not included. If additional distros are later reported as failing, please open an issue with the quickget output for investigation.

---

Fixes #1762
Fixes #1781