### PR TITLE
fix(quickget): resize Batocera image for GPT expansion

### DIFF
--- a/quickget
+++ b/quickget
@@ -3355,7 +3355,10 @@ function create_vm() {
             if [[ ${ISO} = *".gz"* ]]; then
                 gzip -d "${VM_PATH}/${ISO}"
                 ISO="${ISO/.gz/}"
-            fi;;
+            fi
+            # Resize the raw image to provide space for Batocera's partition expansion
+            require_qemu_img
+            ${QEMU_IMG} resize -f raw "${VM_PATH}/${ISO}" 128G;;
         dragonflybsd)
             #  Could be other OS iso files compressed with bzip2 or gzip
             #  but for now we'll keep this to know cases


### PR DESCRIPTION
## Summary

Batocera v41/v42 may fail to boot because the raw image is too small for GPT header relocation and partition expansion during first-boot. The distribution's installer attempts to resize partitions which can cause GPT errors if there's insufficient headroom.

## Changes

- Resize decompressed raw Batocera image to a 128G sparse image (after decompression) so the image has sufficient space for GPT header relocation and subsequent partition expansion.

## Why this works

Providing a larger sparse image gives the GPT and partitioning tools room to relocate headers and expand partitions without corrupting the GPT layout. Using a sparse resize keeps the downloaded image small on disk until space is actually used by the guest.

## Related Issues

Fixes #1794
