### PR TITLE
fix(devshell): enable EFI boot on macOS by patching OVMF paths

### DIFF
--- a/devshell.nix
+++ b/devshell.nix
@@ -55,7 +55,11 @@ mkShell {
           -e '/OVMF_CODE_4M.secboot.fd/s|ovmfs=(|ovmfs=("${OVMFFull.firmware}","${OVMFFull.variables}" |' \
           -e '/OVMF_CODE_4M.fd/s|ovmfs=(|ovmfs=("${OVMF.firmware}","${OVMF.variables}" |' \
         ''
-      } \
+      }${lib.optionalString stdenv.isDarwin ''
+        -e 's|local SHARE_PATH="/usr/share"|local SHARE_PATH="${pkgs.qemu_full}/share"|' \
+        -e 's|ovmfs=("[$][{]SHARE_PATH}/OVMF/OVMF_CODE_4M.secboot.fd"|ovmfs=("${pkgs.qemu_full}/share/qemu/edk2-x86_64-secure-code.fd","${pkgs.qemu_full}/share/qemu/edk2-i386-vars.fd" "''${SHARE_PATH}/OVMF/OVMF_CODE_4M.secboot.fd"|' \
+        -e 's|ovmfs=("[$][{]SHARE_PATH}/OVMF/OVMF_CODE_4M.fd"|ovmfs=("${pkgs.qemu_full}/share/qemu/edk2-x86_64-code.fd","${pkgs.qemu_full}/share/qemu/edk2-i386-vars.fd" "''${SHARE_PATH}/OVMF/OVMF_CODE_4M.fd"|' \
+      ''} \
       -e '/cp "''${VARS_IN}" "''${VARS_OUT}"/a chmod +w "''${VARS_OUT}"' \
       -e 's,\$(command -v smbd),${pkgs.samba}/bin/smbd,' \
       quickemu > $PWD/.direnv/bin/quickemu


### PR DESCRIPTION
Nix's qemu_full bundles EDK2 firmware with different filenames than quickemu expects. Add darwin-specific sed patterns to:
- Set SHARE_PATH to qemu_full's share directory
- Prepend correct firmware paths (edk2-x86_64-code.fd, edk2-i386-vars.fd) to the ovmfs search array

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions