### PR TITLE
feat(quickemu): enable GL on macOS (cocoa) and prefer virtio GL

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -965,7 +965,7 @@ function check_cocoa_gl_es_support() {
 
     # Test QEMU directly for gl=es support - most reliable method
     # This catches both missing OpenGL build support and missing ANGLE libraries
-    if "${QEMU}" -display cocoa,gl=es -M none 2>&1 | grep -qi "OpenGL support was not enabled\|does not accept"; then
+    if "${QEMU}" -display cocoa,gl=es -M none 2>&1 | grep -Eqi "OpenGL support was not enabled|does not accept"; then
         return 1
     fi
 


### PR DESCRIPTION
- Add check_cocoa_gl_es_support(): detect QEMU cocoa gl=es support and look for
  ANGLE/libEGL in QEMU prefix, Homebrew and DYLD paths
- Use the check in configure_display() to enable "gl=es" for cocoa when available
  and fall back to disabling GL (preserving previous stability behaviour)
- Improve virtio GL selection: prefer virtio-gpu(-gl) / virtio-gpu-gl-pci /
  virtio-vga-gl variants when GL is enabled and QEMU exposes the device
- Remove the hard disable of GL for cocoa in display_param_check() (now handled
  by the detection function)
- Ensure user-visible display/GL/VirGL status remains printed for diagnostics
Enables safer GL usage on macOS (covers Nix/Homebrew QEMU and ANGLE cases);
falls back cleanly when support is absent.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions