### PR TITLE
fix(quickemu): set xres/yres only for devices that support them

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -1300,8 +1300,8 @@ function configure_display() {
         VIDEO="-device ramfb ${VIDEO}"
     fi
 
-    # Try and coerce the display resolution for Linux guests only.
-    if [ "${DISPLAY_DEVICE}" != "vmware-svga" ]; then
+    # Set display resolution for devices that support xres/yres parameters
+    if [[ "${DISPLAY_DEVICE}" =~ ^(virtio-(vga|vga-gl|gpu|gpu-gl|gpu-pci|gpu-gl-pci)|qxl|qxl-vga|bochs-display)(,|$) ]]; then
         VIDEO="${VIDEO},xres=${X_RES},yres=${Y_RES}"
         echo " @ (${X_RES} x ${Y_RES})"
     else


### PR DESCRIPTION
- Replace vmware-svga exclusion with explicit device regex
- Apply xres/yres only to virtio-(vga|vga-gl|gpu|gpu-pci|gpu-gl-pci), qxl, qxl-vga and bochs-display
- Prevent passing unsupported xres/yres params to other display devices, avoiding incorrect resolution coercion and QEMU warnings

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code