### PR TITLE
refactor: quote expansions and add ShellCheck directive

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -1820,6 +1820,7 @@ function vm_boot() {
             if [ "${secureboot}" == "on" ]; then
               args+=(-global driver=cfi.pflash01,property=secure,value=on)
             fi
+            # shellcheck disable=SC2054
             args+=(-drive if=pflash,format="${EFI_CODE_FORMAT}",unit=0,file="${EFI_CODE}",readonly=on
                 -drive if=pflash,format="${EFI_VARS_FORMAT}",unit=1,file="${EFI_VARS}")
         fi

--- a/quickget
+++ b/quickget
@@ -900,9 +900,9 @@ function releases_easyos() {
     # get the latest 2 years of releases so that when we hit next year we still have the latest 2 years
     TWO_YEARS=$(web_pipe https://distro.ibiblio.org/easyos/amd64/releases/kirkstone/ | grep -o -E '[[:digit:]]{4}/' | sort -nr | tr -d /  | head -n 2 )
     for YEAR in ${TWO_YEARS} ; do
-        ALL_RELEASES="${ALL_RELEASES} $(web_pipe https://distro.ibiblio.org/easyos/amd64/releases/kirkstone/${YEAR}/ | grep -o -E '[[:digit:]]+(\.[[:digit:]])+/' | tr -d / | sort -nr)"
+        ALL_RELEASES="${ALL_RELEASES} $(web_pipe "https://distro.ibiblio.org/easyos/amd64/releases/kirkstone/${YEAR}/" | grep -o -E '[[:digit:]]+(\.[[:digit:]])+/' | tr -d / | sort -nr)"
     done
-    echo ${ALL_RELEASES}
+    echo "${ALL_RELEASES}"
 }
 
 
@@ -1127,7 +1127,7 @@ function releases_parrotsec() {
             RELEASES="${RELEASES} ${REL}"
         fi
     done
-    echo ${RELEASES}
+    echo "${RELEASES}"
 }
 
 function editions_parrotsec() {


### PR DESCRIPTION
- Quote URL argument passed to web_pipe in quickget to prevent word-splitting
- Quote echoed variables in quickget (echo "${...}") for safe output when values contain whitespace
- Add shellcheck disable=SC2054 in quickemu vm_boot to silence a spurious ShellCheck warning

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code