### PR TITLE
perf(quickemu): enable TRIM/discard and detect-zeroes for qcow2 drives

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -1871,6 +1871,9 @@ function vm_boot() {
 
     # Add the disks
     # - https://turlucode.com/qemu-disk-io-performance-comparison-native-or-threads-windows-10-version/
+    # Optimise disk I/O: enable TRIM/discard and zero detection for thin provisioning
+    DRIVE_OPTIMISATIONS="discard=unmap,detect-zeroes=unmap"
+
     if [[ "${boot}" == *"efi"* ]]; then
         QCOW2CODE=$(is_firmware_qcow2 "${EFI_CODE}")
         QCOW2VARS=$(is_firmware_qcow2 "${EFI_VARS}")
@@ -1971,13 +1974,13 @@ function vm_boot() {
 
             # shellcheck disable=SC2054,SC2206
             args+=(-device ${MAC_DISK_DEV},drive=SystemDisk
-                -drive id=SystemDisk,if=none,format=qcow2,file="${disk_img}" ${STATUS_QUO})
+                -drive id=SystemDisk,if=none,format=qcow2,file="${disk_img}",${DRIVE_OPTIMISATIONS} ${STATUS_QUO})
         else
             # Integrated mode: OpenCore is in the main disk's EFI partition
             # Boot directly from the main disk
             # shellcheck disable=SC2054,SC2206
             args+=(-device ${MAC_DISK_DEV},drive=SystemDisk,bootindex=0
-                -drive id=SystemDisk,if=none,format=qcow2,file="${disk_img}" ${STATUS_QUO})
+                -drive id=SystemDisk,if=none,format=qcow2,file="${disk_img}",${DRIVE_OPTIMISATIONS} ${STATUS_QUO})
 
             if [ -n "${img}" ]; then
                 # shellcheck disable=SC2054
@@ -1989,14 +1992,14 @@ function vm_boot() {
         # shellcheck disable=SC2054,SC2206
         args+=(-device ahci,id=ahci
             -device ide-hd,bus=ahci.0,drive=SystemDisk
-            -drive id=SystemDisk,if=none,format=qcow2,file="${disk_img}" ${STATUS_QUO})
+            -drive id=SystemDisk,if=none,format=qcow2,file="${disk_img}",${DRIVE_OPTIMISATIONS} ${STATUS_QUO})
 
     elif [ "${guest_os}" == "batocera" ] ; then
         # shellcheck disable=SC2054,SC2206
         args+=(-device virtio-blk-pci,drive=BootDisk
             -drive id=BootDisk,if=none,format=raw,file="${img}"
             -device virtio-blk-pci,drive=SystemDisk
-            -drive id=SystemDisk,if=none,format=qcow2,file="${disk_img}" ${STATUS_QUO})
+            -drive id=SystemDisk,if=none,format=qcow2,file="${disk_img}",${DRIVE_OPTIMISATIONS} ${STATUS_QUO})
 
     elif [ "${guest_os}" == "reactos" ]; then
         # https://reactos.org/wiki/QEMU
@@ -2006,18 +2009,18 @@ function vm_boot() {
     elif [ "${guest_os}" == "windows-server" ]; then
         # shellcheck disable=SC2054,SC2206
         args+=(-device ide-hd,drive=SystemDisk
-            -drive id=SystemDisk,if=none,format=qcow2,file="${disk_img}" ${STATUS_QUO})
+            -drive id=SystemDisk,if=none,format=qcow2,file="${disk_img}",${DRIVE_OPTIMISATIONS} ${STATUS_QUO})
 
     else
         if [ "${ARCH_VM}" == "aarch64" ]; then
             # ARM64: bootindex=2 ensures disk boots after CD-ROM (bootindex=1) during installation
             # shellcheck disable=SC2054,SC2206
             args+=(-device virtio-blk-pci,drive=SystemDisk,bootindex=2
-                -drive id=SystemDisk,if=none,format=${disk_format},file="${disk_img}" ${STATUS_QUO})
+                -drive id=SystemDisk,if=none,format=${disk_format},file="${disk_img}",${DRIVE_OPTIMISATIONS} ${STATUS_QUO})
         else
             # shellcheck disable=SC2054,SC2206
             args+=(-device virtio-blk-pci,drive=SystemDisk
-                -drive id=SystemDisk,if=none,format=${disk_format},file="${disk_img}" ${STATUS_QUO})
+                -drive id=SystemDisk,if=none,format=${disk_format},file="${disk_img}",${DRIVE_OPTIMISATIONS} ${STATUS_QUO})
         fi
     fi
 


### PR DESCRIPTION
Enabling `discard=unmap` passes guest TRIM requests through to the qcow2
layer, allowing automatic disk space reclamation as guests delete files,
while `detect-zeroes=unmap` converts zero-block writes into additional
discard operations for further space savings. This configuration mirrors
Proxmox VE's default settings, where it has proven stable across millions
of production VMs since QEMU 1.5.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my code