### PR TITLE
fix(quickemu): select correct sound card for macOS guests

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -1094,13 +1094,24 @@ function configure_os_quirks() {
             #   * VirtIO Memory Balloning is supported since Big Sur (https://pmhahn.github.io/virtio-balloon/)
             #   * VirtIO RNG is supported since Big Sur, but exposed to all guests by default.
             case ${macos_release} in
-                big-sur|monterey|ventura|sonoma|sequoia|tahoe)
+                monterey|ventura|sonoma|sequoia|tahoe)
+                    # macOS 12+ (Monterey onwards) supports virtio-sound-pci natively
                     BALLOON="-device virtio-balloon"
                     MAC_DISK_DEV="virtio-blk-pci"
                     NET_DEVICE="virtio-net-pci"
                     USB_HOST_PASSTHROUGH_CONTROLLER="nec-usb-xhci"
                     GUEST_TWEAKS+=" -global nec-usb-xhci.msi=off"
-                    sound_card="${sound_card:-usb-audio}"
+                    sound_card="${sound_card:-virtio-sound-pci}"
+                    usb_controller="xhci";;
+                big-sur)
+                    # Big Sur uses VirtIO but usb-audio/VoodooHDA don't work reliably
+                    # Fall back to ich9-intel-hda which may work with VoodooHDA
+                    BALLOON="-device virtio-balloon"
+                    MAC_DISK_DEV="virtio-blk-pci"
+                    NET_DEVICE="virtio-net-pci"
+                    USB_HOST_PASSTHROUGH_CONTROLLER="nec-usb-xhci"
+                    GUEST_TWEAKS+=" -global nec-usb-xhci.msi=off"
+                    sound_card="${sound_card:-ich9-intel-hda}"
                     usb_controller="xhci";;
                 *)
                     # Backwards compatibility if no macos_release is specified.
@@ -1398,6 +1409,7 @@ function configure_audio() {
     case ${sound_card} in
         ich9-intel-hda|intel-hda) SOUND="-device ${sound_card} -device ${sound_duplex},audiodev=audio0";;
         usb-audio) SOUND="-device ${sound_card},audiodev=audio0";;
+        virtio-sound-pci) SOUND="-device ${sound_card},audiodev=audio0";;
         ac97|es1370|sb16) SOUND="-device ${sound_card},audiodev=audio0";;
         none) SOUND="";;
     esac
@@ -2245,7 +2257,7 @@ function usage() {
     echo "  --keyboard_layout <layout>        : Set keyboard layout: 'en-us' (default)"
     echo "  --mouse <type>                    : Set mouse. @Options: 'tablet' (default), 'ps2', 'usb', 'virtio'"
     echo "  --usb-controller <type>           : Set usb-controller. @Options: 'ehci' (default), 'xhci', 'none'"
-    echo "  --sound-card <type>               : Set sound card. @Options: 'intel-hda' (default), 'ac97', 'es1370', 'sb16', 'usb-audio', 'none'"
+    echo "  --sound-card <type>               : Set sound card. @Options: 'intel-hda' (default), 'ac97', 'es1370', 'sb16', 'usb-audio', 'virtio-sound-pci', 'none'"
     echo "  --sound-duplex <type>             : Set sound card duplex. @Options: 'hda-micro' (default: speaker/mic), 'hda-duplex' (line-in/line-out), 'hda-output' (output-only)"
     echo "  --extra_args <arguments>          : Pass additional arguments to qemu"
     echo "  --version                         : Print version"
@@ -2311,7 +2323,7 @@ function ports_param_check() {
 }
 
 function sound_card_param_check() {
-    if [ "${sound_card}" != "ac97" ] && [ "${sound_card}" != "es1370" ] && [ "${sound_card}" != "ich9-intel-hda" ] && [ "${sound_card}" != "intel-hda" ] && [ "${sound_card}" != "sb16" ] && [ "${sound_card}" != "usb-audio" ] && [ "${sound_card}" != "none" ]; then
+    if [ "${sound_card}" != "ac97" ] && [ "${sound_card}" != "es1370" ] && [ "${sound_card}" != "ich9-intel-hda" ] && [ "${sound_card}" != "intel-hda" ] && [ "${sound_card}" != "sb16" ] && [ "${sound_card}" != "usb-audio" ] && [ "${sound_card}" != "virtio-sound-pci" ] && [ "${sound_card}" != "none" ]; then
         echo "ERROR! Requested sound card '${sound_card}' is not recognised."
         exit 1
     fi


### PR DESCRIPTION
- Split macOS sound card logic by OS version:
  - Use virtio-sound-pci for macOS 12+ (Monterey and newer)
  - Use ich9-intel-hda for Big Sur
  - Keep intel-hda for earlier macOS releases
- Add virtio-sound-pci case to configure_audio() to pair the device with existing audiodev backends (PulseAudio, PipeWire, ALSA, CoreAudio)
- Update help text to include virtio-sound-pci as an allowed sound card option
- Add virtio-sound-pci to allowed sound cards in sound_card_param_check()

VoodooHDA injected via OpenCore stopped working from macOS 11.3+ onwards and usb-audio proved unreliable for Big Sur+. virtio-sound-pci works natively on macOS 12+ without kexts and fixes guest audio for affected versions.

Fixes #1642

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation (updates the documentation)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (*remove if no documentation changes were required*)