### PR TITLE
fix(quickemu): enable vmware TSC and disable ACPI PCI hotplug for macOS

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -2551,8 +2551,8 @@ QEMU_VER_LONG=$(${QEMU_IMG} --version | head -n 1 | awk '{print $3}')
 QEMU_VER_SHORT="${QEMU_VER_LONG%.*}"
 QEMU_VER_SHORT="${QEMU_VER_SHORT/./}"
 
-if [ "${QEMU_VER_SHORT}" -lt 60 ]; then
-    echo "ERROR! QEMU 6.0.0 or newer is required, detected ${QEMU_VER_LONG}."
+if [ "${QEMU_VER_SHORT}" -lt 61 ]; then
+    echo "ERROR! QEMU 6.1.0 or newer is required, detected ${QEMU_VER_LONG}."
     exit 1
 fi
 


### PR DESCRIPTION
- Pass vmware-cpuid-freq=on to -cpu on Intel hosts to enable VMware TSC frequency reporting and improve macOS timing
- Add ICH9-LPC flag to disable ACPI PCI hotplug bridge support to avoid macOS PCI hotplug issues (required for QEMU 6.1+)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code