### PR TITLE
fix(quickemu): enable xhci when braille devices used

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -2269,6 +2269,8 @@ function display_param_check() {
     # Braille support requires SDL. Override $display if braille was requested.
     if [ -n "${BRAILLE}" ]; then
         display="sdl"
+        # XHCI supports USB 1.1/2.0/3.0; required for full-speed braille devices
+        usb_controller="xhci"
     fi
 
     if [ "${OS_KERNEL}" == "Darwin" ]; then


### PR DESCRIPTION
- Set usb_controller="xhci" in display_param_check() when BRAILLE is enabled.
- Braille devices are USB 1.1 (full-speed); EHCI only handles USB 2.0/3.0, which causes speed mismatch warnings and prevents braille devices from working.

Fixes #730

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code