### PR TITLE
fix(quickget): exit on curl failure in web_get

### DIFF
--- a/quickget
+++ b/quickget
@@ -1618,6 +1618,7 @@ function web_get() {
     if ! curl --disable --progress-bar --location --output "${DIR}/${FILE}" --continue-at - --user-agent "${USER_AGENT}" "${HEADERS[@]}" -- "${URL}"; then
         echo "ERROR! Failed to download ${URL} with curl."
         rm -f "${DIR}/${FILE}"
+        exit 1
     fi
 }
 


### PR DESCRIPTION
Add exit 1 after curl failure handling in web_get

- Exit immediately when a download via curl fails
- Prevent continuing to build invalid VM configs after failed download

Fixes #1625

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code