### PR TITLE
fix(quickemu): disable GL when display backend is none

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -1337,7 +1337,9 @@ function configure_display() {
                 [ "${gl}" == "on" ] && gl="off"
             fi;;
         gtk)        DISPLAY_RENDER="${display},grab-on-hover=on,zoom-to-fit=off,gl=${gl}";;
-        none|spice) DISPLAY_RENDER="none";;
+        none)       DISPLAY_RENDER="none"
+                    gl="off";;  # No display backend means no GL context
+        spice)      DISPLAY_RENDER="none";;
         sdl)        DISPLAY_RENDER="${display},gl=${gl}";;
         spice-app)  DISPLAY_RENDER="${display},gl=${gl}";;
         *)          DISPLAY_RENDER="${display}";;


### PR DESCRIPTION
- Disable GL context creation when no display backend is selected by setting gl="off"
- Keep spice behaviour unchanged (DISPLAY_RENDER remains "none")
- Prevent GL-related errors and unnecessary GPU initialisation for headless VMs

## Type of change

<!-- Delete any that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code