### PR TITLE
feat(quickget): add Azure Linux (3.0) support

### DIFF
--- a/quickget
+++ b/quickget
@@ -2012,7 +2012,7 @@ function get_azurelinux() {
     local QEMU_ARCH="x86_64"
     [ "${ARCH}" == "arm64" ] && QEMU_ARCH="aarch64"
     local URL="https://aka.ms/azurelinux-${RELEASE}-${QEMU_ARCH}.iso"
-    ISO=$(web_redirect "${URL}")
+    local ISO="$(web_redirect "${URL}")"
     echo "${ISO}"
 }
 


### PR DESCRIPTION
- Add os_info() case entry with a description for Azure Linux
- Add Azure Linux to os_support() list
- Implement releases_azurelinux() returning "3.0"
- Implement arch_azurelinux() returning "amd64 arm64"
- Implement get_azurelinux() using stable aka.ms download URLs:
  - https://aka.ms/azurelinux-3.0-x86_64.iso
  - https://aka.ms/azurelinux-3.0-aarch64.iso
  
Closes #1459

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my code