### PR TITLE
perf(quickemu): improve disk I/O defaults (cache,aio)

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -1887,8 +1887,9 @@ function vm_boot() {
 
     # Add the disks
     # - https://turlucode.com/qemu-disk-io-performance-comparison-native-or-threads-windows-10-version/
-    # Optimise disk I/O: enable TRIM/discard and zero detection for thin provisioning
-    DRIVE_OPTIMISATIONS="discard=unmap,detect-zeroes=unmap"
+    # Optimise disk I/O: enable TRIM/discard, zero detection for thin provisioning,
+    # writeback caching and threaded async I/O
+    DRIVE_OPTIMISATIONS="discard=unmap,detect-zeroes=unmap,cache=writeback,aio=threads"
 
     if [[ "${boot}" == *"efi"* ]]; then
         QCOW2CODE=$(is_firmware_qcow2 "${EFI_CODE}")


### PR DESCRIPTION
- add cache=writeback and aio=threads to DRIVE_OPTIMISATIONS
- retain existing optimisations: discard=unmap,detect-zeroes=unmap
- improve write performance (host writeback caching) and async I/O parallelism via thread-based AIO
- follows Proxmox/libvirt QEMU disk best practices; researched for macOS but applies to all guests

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my code