### PR TITLE
fix(quickemu): only add 'topoext' cpu flag for x86_64 AMD guests

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -726,7 +726,7 @@ function configure_cpu() {
             ;;
     esac
 
-    if [ "${HOST_CPU_VENDOR}" == "AuthenticAMD" ] && [ "${guest_os}" != "macos" ]; then
+    if [ "${HOST_CPU_VENDOR}" == "AuthenticAMD" ] && [ "${guest_os}" != "macos" ] && [ "${ARCH_VM}" == "x86_64" ]; then
         add_cpu_flag "topoext"
     fi
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions