### PR TITLE
fix(macos): prevent default sound card overriding the compatible selection

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -1103,7 +1103,7 @@ function configure_os_quirks() {
                     NET_DEVICE="virtio-net-pci"
                     USB_HOST_PASSTHROUGH_CONTROLLER="nec-usb-xhci"
                     GUEST_TWEAKS+=" -global nec-usb-xhci.msi=off"
-                    sound_card="${sound_card:-virtio-sound-pci}"
+                    sound_card="virtio-sound-pci"
                     usb_controller="xhci";;
                 big-sur)
                     # Big Sur uses VirtIO but usb-audio/VoodooHDA don't work reliably
@@ -1113,7 +1113,7 @@ function configure_os_quirks() {
                     NET_DEVICE="virtio-net-pci"
                     USB_HOST_PASSTHROUGH_CONTROLLER="nec-usb-xhci"
                     GUEST_TWEAKS+=" -global nec-usb-xhci.msi=off"
-                    sound_card="${sound_card:-ich9-intel-hda}"
+                    sound_card="ich9-intel-hda"
                     usb_controller="xhci";;
                 *)
                     # Backwards compatibility if no macos_release is specified.


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions