### PR TITLE
fix(quickemu): read "Vendor ID" for CPU vendor detection

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -477,7 +477,11 @@ function configure_cpu() {
     HOST_CPU_CORES=$(get_nproc)
     HOST_CPU_MODEL=$(get_cpu_info '^Model name:')
     HOST_CPU_SOCKETS=$(get_cpu_info 'Socket')
-    HOST_CPU_VENDOR=$(get_cpu_info '^Vendor ID')
+    if [ "${OS_KERNEL}" == "Darwin" ]; then
+        HOST_CPU_VENDOR=$(get_cpu_info 'Vendor')
+    else
+        HOST_CPU_VENDOR=$(get_cpu_info '^Vendor ID')
+    fi
 
     if [ "${HOST_CPU_SOCKETS}" = "-" ]; then
         HOST_CPU_SOCKETS=1


### PR DESCRIPTION
- Change HOST_CPU_VENDOR lookup to use '^Vendor ID' when parsing /proc/cpuinfo
- Ensures correct CPU vendor detection on systems that label the field as 'Vendor ID' instead of 'Vendor'

Fixes #1845

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code