### PR TITLE
fix(quickemu): use vmware-svga display for macOS guests

### DIFF
--- a/quickemu
+++ b/quickemu
@@ -1299,8 +1299,8 @@ function configure_display() {
                 esac
             fi;;
         macos)
-            # VGA supports seamless mouse and sane resolutions for macOS guests
-            DISPLAY_DEVICE="VGA";;
+            # macOS has native VMware display driver support; aligns with OSX-KVM
+            DISPLAY_DEVICE="vmware-svga";;
         windows|windows-server)
             case ${display} in
                 none|spice) DISPLAY_DEVICE="qxl-vga";;


### PR DESCRIPTION
- Replace previous VGA default with vmware-svga to align with macOS native VMware display driver and OSX-KVM expectations
- Improve resolution handling and mouse integration for macOS VMs

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code