### PR TITLE
feat: add support for passing extra arguments to the SPICE viewer

### DIFF
--- a/docs/quickemu.1.md
+++ b/docs/quickemu.1.md
@@ -259,7 +259,7 @@ These should be handled by dependencies in Trixie and later. For earlier
 versions (and their derivatives):
 
 ``` shell
-sudo apt-get install bash coreutils curl genisoimage grep jq mesa-utils ovmf pciutils procps python3 qemu sed socat spice-client-gtk swtpm-tools unzip usbutils util-linux xdg-user-dirs xrandr zsync 
+sudo apt-get install bash coreutils curl genisoimage grep jq mesa-utils ovmf pciutils procps python3 qemu sed socat spice-client-gtk swtpm-tools unzip usbutils util-linux xdg-user-dirs xrandr zsync
 ```
 
 #### Install requirements on Fedora hosts

--- a/docs/quickemu.1.md
+++ b/docs/quickemu.1.md
@@ -75,7 +75,7 @@ You can also pass optional parameters
 :   Do not commit any changes to disk/snapshot.
 
 **--viewer \<viewer\>**
-:   Choose an alternative viewer. @Options: 'spicy' (default),
+:   Choose an alternative SPICE viewer. @Options: 'spicy' (default),
     'remote-viewer', 'none'
 
 **--width \<width\>**
@@ -784,7 +784,7 @@ Arguments
   --snapshot delete <tag>           : Delete a snapshot.
   --snapshot info                   : Show disk/snapshot info.
   --status-quo                      : Do not commit any changes to disk/snapshot.
-  --viewer <viewer>                 : Choose an alternative viewer. @Options: 'spicy' (default), 'remote-viewer', 'none'
+  --viewer <viewer>                 : Choose an alternative SPICE viewer. @Options: 'spicy' (default), 'remote-viewer', 'none'
   --width <width>                   : Set VM screen width; requires '--height'
   --height <height>                 : Set VM screen height; requires '--width'
   --ssh-port <port>                 : Set SSH port manually

--- a/docs/quickemu_conf.5.md
+++ b/docs/quickemu_conf.5.md
@@ -46,6 +46,7 @@ secureboot="off"
 tpm="off"
 usb_devices=()
 viewer="spicy"
+viewer_extra_args=""
 ssh_port=""
 spice_port=""
 public_dir=""
@@ -272,6 +273,18 @@ device selection*) support this feature.
 
 To ensure that this functionality works as expected, make sure that you
 have installed the necessary SPICE Guest Tools on the virtual machine.
+
+Automatic redirection of specific devices can be configured in the
+configuration file by setting the `viewer_extra_args` variable.
+
+For example (in the configuration file):
+
+    viewer_extra_args="--spice-usbredir-redirect-on-connect=-1,0x1234,0x5678,-1,1"
+
+Where `0x1234` and `0x5678` are example USB VID and PID, respectively.
+
+The string format is described at:
+<https://www.spice-space.org/usbredir.html#filter-string-format>.
 
 ##### Enabling SPICE redirection on NixOS
 

--- a/quickemu
+++ b/quickemu
@@ -2307,7 +2307,7 @@ function usage() {
     echo "  --snapshot delete <tag>           : Delete a snapshot."
     echo "  --snapshot info                   : Show disk/snapshot info."
     echo "  --status-quo                      : Do not commit any changes to disk/snapshot."
-    echo "  --viewer <viewer>                 : Choose an alternative viewer. @Options: 'spicy' (default), 'remote-viewer', 'none'"
+    echo "  --viewer <viewer>                 : Choose an alternative SPICE viewer. @Options: 'spicy' (default), 'remote-viewer', 'none'"
     echo "  --width <width>                   : Set VM screen width; requires '--height'"
     echo "  --height <height>                 : Set VM screen height; requires '--width'"
     echo "  --ssh-port <port>                 : Set SSH port manually"

--- a/quickemu
+++ b/quickemu
@@ -2243,6 +2243,12 @@ function start_viewer {
         viewer_args+=("${viewer_uri}")
     fi
 
+    # Add extra arguments
+    if [ -n "${viewer_extra_args}" ]; then
+        # shellcheck disable=SC2206
+        viewer_args+=(${viewer_extra_args})
+    fi
+
     # Launch the viewer
     echo " - Viewer:   ${viewer} ${viewer_args[*]} >/dev/null 2>&1 &"
     "${viewer}" "${viewer_args[@]}" >/dev/null 2>&1 &
@@ -2550,6 +2556,7 @@ secureboot="off"
 tpm="off"
 usb_devices=()
 viewer="${viewer:-spicy}"
+viewer_extra_args="${viewer_extra_args:-}"
 width="${width:-}"
 height="${height:-}"
 ssh_port="${ssh_port:-}"


### PR DESCRIPTION
# Description

This PR adds support for passing additional arguments to the SPICE viewer. The feature was added mainly to support passing `--spice-usbredir-redirect-on-connect` in order to support automatic USB device redirection. For example (in a configuration file):

```bash
viewer_extra_args="--spice-usbredir-redirect-on-connect=-1,0x1234,0x5678,-1,1"
```

Where `0x1234` and `0x5678` are example USB VID and PID, respectively.

The string format is described at <https://www.spice-space.org/usbredir.html#filter-string-format>.

This PR also contains a minor style commit (removing trailing whitespace) and another commit clarifying that "viewer" actually refers to the SPICE viewer.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation (updates the documentation)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [x] I have added comments to my code, particularly in hard-to-understand sections
- [x] I have made corresponding changes to the documentation
