### PR TITLE
fix(quickget): arm64 support for Fedora editions

### DIFF
--- a/quickget
+++ b/quickget
@@ -1227,8 +1227,8 @@ function arch_debian() {
 
 function arch_fedora() {
     case "${EDITION}" in
-        Server) echo "amd64 arm64";;
-        *) echo "amd64";;
+        Onyx) echo "amd64";;
+        *) echo "amd64 arm64";;
     esac
 }
 


### PR DESCRIPTION
Maybe it was accurate in this past but the current Quickget release suggest that only Fedora Server has arm64 support. That's not the case. In fact checking the `releases.json` file that `quickget` already uses shows us that every edition other than Onyx supports arm64.

This PR makes that change.

The command ran to check this info was:

```bash
curl -sL https://getfedora.org/releases.json | jq -r 'group_by(.variant)[] | "\(.[0].variant): \(map(.arch) | unique |
join(", "))"'

COSMIC-Atomic: aarch64, x86_64
Cloud: aarch64, ppc64le, s390x, x86_64
Container: aarch64, ppc64le, s390x, x86_64
Everything: aarch64, ppc64le, s390x, x86_64
IoT: aarch64, ppc64le, s390x, x86_64
KDE: aarch64, ppc64le, x86_64
Kinoite: aarch64, ppc64le, x86_64
Labs: aarch64, x86_64
Onyx: x86_64
Sericea: aarch64, x86_64
Server: aarch64, ppc64le, s390x, x86_64
Silverblue: aarch64, ppc64le, x86_64
Spins: aarch64, x86_64
Workstation: aarch64, ppc64le, x86_64
```

Fixes: #1870


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Packaging (updates the packaging)
- [ ] Documentation (updates the documentation)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have tested my code in common scenarios and confirmed there are no regressions
- [ ] I have added comments to my code, particularly in hard-to-understand sections
