### PR TITLE
fix(quickget): add --insecure flag to skip SSL certificate verification

### DIFF
--- a/quickget
+++ b/quickget
@@ -1413,6 +1413,8 @@ function web_pipe_json() {
 function web_get() {
     local CHECK=""
     local HEADERS=()
+    local INSECURE=()
+    [ "${CURL_INSECURE}" == "true" ] && INSECURE=("--insecure")
     local URL="${1}"
     local DIR="${2}"
     local FILE=""
@@ -1464,7 +1466,7 @@ function web_get() {
         echo "- URL: ${URL}"
     fi
 
-    if ! curl --disable --progress-bar --location --output "${DIR}/${FILE}" --continue-at - --user-agent "${USER_AGENT}" "${HEADERS[@]}" -- "${URL}"; then
+    if ! curl --disable --progress-bar --location --output "${DIR}/${FILE}" --continue-at - --user-agent "${USER_AGENT}" "${HEADERS[@]}" "${INSECURE[@]}" -- "${URL}"; then
         echo "ERROR! Failed to download ${URL} with curl."
         rm -f "${DIR}/${FILE}"
         exit 1
@@ -3766,6 +3768,7 @@ Arguments:
    --arch           <arch>                    : Set architecture (arm64, aarch64, amd64, x86_64)
    --download       <os> <release> [edition]  : Download image; no VM configuration
    --create-config  <os> [path/url] [flags]   : Create VM config for an OS image
+   --insecure                                 : Skip SSL certificate verification (or set QUICKGET_INSECURE=1)
    --open-homepage  <os>                      : Open homepage for the OS
    --show           [os]                      : Show OS information
    --version                                  : Show version
@@ -3797,6 +3800,7 @@ QUICKEMU=$(resolve_quickemu)
 I18NS=()
 OPERATION=""
 CHECK_ALL_ARCH="false"
+CURL_INSECURE="${QUICKGET_INSECURE:-false}"
 # Normalised host architecture for foreign arch detection
 NORMALISED_HOST_ARCH="${ARCH}"
 CURL=$(command -v curl)
@@ -3915,6 +3919,10 @@ case "${1}" in
     --list-csv|-list-csv|list|list_csv) list_csv;;
     --list-json|-list-json|list_json) list_json;;
     --list|-list) list_supported;;
+    --insecure|-insecure)
+        CURL_INSECURE="true"
+        shift
+        ;;
     -*) error_not_supported_argument;;
 esac
 

--- a/quickget
+++ b/quickget
@@ -3800,7 +3800,8 @@ QUICKEMU=$(resolve_quickemu)
 I18NS=()
 OPERATION=""
 CHECK_ALL_ARCH="false"
-CURL_INSECURE="${QUICKGET_INSECURE:-false}"
+CURL_INSECURE="false"
+[[ "${QUICKGET_INSECURE:-}" == "1" || "${QUICKGET_INSECURE:-}" == "true" ]] && CURL_INSECURE="true"
 # Normalised host architecture for foreign arch detection
 NORMALISED_HOST_ARCH="${ARCH}"
 CURL=$(command -v curl)


### PR DESCRIPTION
## Problem

Some download hosts (currently `spice-space.org`) serve content with expired SSL certificates, causing `curl` to refuse the connection and `quickget` to fail with an error like:

```
curl: (60) SSL certificate problem: certificate has expired
ERROR! Failed to download https://www.spice-space.org/download/windows/spice-webdavd/spice-webdavd-x64-latest.msi with curl.
```

## Solution

Add an opt-in `--insecure` flag and a `QUICKGET_INSECURE=1` environment variable that pass `--insecure` to `curl`, bypassing certificate verification. This is **off by default** — normal usage is unaffected.

```bash
# via CLI flag
quickget --insecure windows 11

# via env var
QUICKGET_INSECURE=1 quickget windows 11
```

## Changes

- `web_get`: reads a global `CURL_INSECURE` variable and passes `--insecure` to `curl` when set
- `CURL_INSECURE` global: defaults to `false`, picks up `QUICKGET_INSECURE` from the environment
- `--insecure` / `-insecure` CLI flag in the argument parser
- Help text updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)