### PR TITLE
fix(quickget): emit curl progress and size to stdout when piped

### DIFF
--- a/quickget
+++ b/quickget
@@ -1464,7 +1464,17 @@ function web_get() {
         echo "- URL: ${URL}"
     fi
 
-    if ! curl --disable --progress-bar --location --output "${DIR}/${FILE}" --continue-at - --user-agent "${USER_AGENT}" "${HEADERS[@]}" -- "${URL}"; then
+    local PIPE_OPTS=()
+    if [ ! -t 1 ]; then
+        local CONTENT_LENGTH
+        CONTENT_LENGTH=$(curl --disable --silent --head --location \
+            --write-out '%{content_length_download}' --output /dev/null \
+            --user-agent "${USER_AGENT}" "${HEADERS[@]}" -- "${URL}" 2>/dev/null)
+        [ -n "${CONTENT_LENGTH}" ] && echo "content-length: ${CONTENT_LENGTH}"
+        PIPE_OPTS=("--stderr" "-")
+    fi
+
+    if ! curl --disable --progress-bar "${PIPE_OPTS[@]}" --location --output "${DIR}/${FILE}" --continue-at - --user-agent "${USER_AGENT}" "${HEADERS[@]}" -- "${URL}"; then
         echo "ERROR! Failed to download ${URL} with curl."
         rm -f "${DIR}/${FILE}"
         exit 1


### PR DESCRIPTION
Description

  When quickget is called from a GUI or script (stdout is a pipe, not a TTY), curl's progress output is suppressed and the caller receives no feedback until
  the download finishes.

  This fix adds two behaviours when stdout is not a TTY:

  - A separate curl --head request fetches the correct total file size and emits it as content-length: N to stdout before the download starts. This avoids the
  ambiguity of --dump-header with redirects (multiple header blocks) or 206 resume responses (Content-Length = remaining bytes, not total).
  - --stderr - is added to the download curl call so the --progress-bar output is written to stdout, letting callers parse real-time percentage.

  Normal terminal behaviour is completely unchanged — PIPE_OPTS stays empty when stdout is a TTY.

  - Fixes #1921

  Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)

  Checklist
  - [x] I have performed a self-review of my code
  - [x] I have tested my code in common scenarios and confirmed there are no regressions